### PR TITLE
Fix Python 3.10 minor version in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: [3.8, 3.9, 3.10.8]
         os: [ubuntu-latest]  # , macos-latest]
 
     steps:


### PR DESCRIPTION
Specifying `3.10.7` seems to have broken recently in GitHub, as seen on #48 