### PR TITLE
Fix setup.cfg formatting for latest flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [flake8]
 max-line-length = 120
 extend-ignore =
-    E203  # https://github.com/psf/black/blob/master/docs/the_black_code_style.md#slices
+    # https://github.com/psf/black/blob/master/docs/the_black_code_style.md#slices
+    E203
 per_file_ignores = 
     causal_pyro/reparam/__init__.py:E501


### PR DESCRIPTION
Blocking CI from completing successfully for all PRs, including #74 

Applies fix taken from [here](https://stackoverflow.com/questions/74558565/flake8-error-code-supplied-to-ignore-option-does-not-match-a-z1-30).