### PR TITLE
Remove Python minor version number from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: [3.8, 3.9, '3.10']
         os: [ubuntu-latest]  # , macos-latest]
 
     steps:


### PR DESCRIPTION
Blocking CI on open PRs including #76 