### PR TITLE
Add a requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -80,4 +80,5 @@ urllib3==1.26.13
 wcwidth==0.2.5
 webencodings==0.5.1
 
+# Since we're in causal_pyro/docs, ".." specifies that causal pyro should be installed
 ..


### PR DESCRIPTION
This PR adds a `docs/requirements.txt`. The approach is

1. Make a `venv` environment
2. `pip install` things until `make html` works from the docs directory
3. `pip freeze`

Note that the `causal-pyro` line is still off. I'd guess it needs to be `causal-pyro==0.1`. @eb8680 does that sound right?