### PR TITLE
removed param from _process_message

### DIFF
--- a/causal_pyro/counterfactual/internals.py
+++ b/causal_pyro/counterfactual/internals.py
@@ -225,9 +225,7 @@ class _LazyPlateMessenger(IndepMessenger):
         )
 
     def _process_message(self, msg):
-        if msg["type"] not in (
-            "sample",
-        ) or pyro.poutine.util.site_is_subsample(msg):
+        if msg["type"] not in ("sample",) or pyro.poutine.util.site_is_subsample(msg):
             return
         if self.frame.name in union(indices_of(msg["value"]), indices_of(msg["fn"])):
             super()._process_message(msg)


### PR DESCRIPTION
This PR appears to address #111 , which would then unblock #106 . I'm not seeing anywhere in the Causal Pyro repo where we'd need to process messages on parameters, so it seems safe to remove. That being said, I'm not confident and would appreciate another pair of eyes.

With this PR all tests still pass locally.