### PR TITLE
Dynamic Interventions WIP

### DIFF
--- a/causal_pyro/dynamical/handlers.py
+++ b/causal_pyro/dynamical/handlers.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import (
     Any,
     Callable,
+    Dict,
     Generic,
     Hashable,
     List,
@@ -14,7 +15,6 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    Dict
 )
 
 import pyro
@@ -22,16 +22,14 @@ import torch
 import torchdiffeq
 
 from causal_pyro.dynamical.ops import (
-    State,
-    Trajectory,
     Dynamics,
     State,
     Trajectory,
+    apply_interruptions,
     concatenate,
-    simulate_span,
     simulate,
+    simulate_span,
     simulate_to_interruption,
-    apply_interruptions
 )
 from causal_pyro.interventional.handlers import do
 from causal_pyro.interventional.ops import intervene
@@ -285,13 +283,19 @@ class SimulatorEventLoop(pyro.poutine.messenger.Messenger):
             # Block any interruption's application that wouldn't be the result of an interruption that ended the last
             #  simulation.
             with pyro.poutine.messenger.block_messengers(
-                    lambda m: isinstance(m, Interruption) and m not in last_terminal_interruptions):
-                dynamics, span_start_state = apply_interruptions(dynamics, span_start_state)
+                lambda m: isinstance(m, Interruption)
+                and m not in last_terminal_interruptions
+            ):
+                dynamics, span_start_state = apply_interruptions(
+                    dynamics, span_start_state
+                )
 
             # Block dynamic interventions that have triggered and applied more than the specified number of times.
             # This will prevent them from percolating up to the simulate_to_interruption execution.
             with pyro.poutine.messenger.block_messengers(
-                    lambda m: isinstance(m, DynamicIntervention) and m.max_applications <= interruption_counts.get(m, 0)):
+                lambda m: isinstance(m, DynamicIntervention)
+                and m.max_applications <= interruption_counts.get(m, 0)
+            ):
                 (
                     span_traj,
                     terminal_interruptions,
@@ -310,10 +314,15 @@ class SimulatorEventLoop(pyro.poutine.messenger.Messenger):
                 )  # type: Trajectory[T], Tuple['Interruption', ...], float, State[T]
 
             if len(terminal_interruptions) > 1:
-                warnings.warn("Multiple events fired simultaneously. This results in undefined behavior.", UserWarning)
+                warnings.warn(
+                    "Multiple events fired simultaneously. This results in undefined behavior.",
+                    UserWarning,
+                )
 
             for interruption in terminal_interruptions:
-                interruption_counts[interruption] = interruption_counts.get(interruption, 0) + 1
+                interruption_counts[interruption] = (
+                    interruption_counts.get(interruption, 0) + 1
+                )
 
             last = default_terminal_interruption in terminal_interruptions
 
@@ -424,10 +433,7 @@ class _InterventionMixin(Interruption):
 
     def _pyro_apply_interruptions(self, msg) -> None:
         dynamics, initial_state = msg["args"]
-        msg["args"] = (
-            dynamics,
-            intervene(initial_state, self.intervention)
-        )
+        msg["args"] = (dynamics, intervene(initial_state, self.intervention))
 
 
 class PointIntervention(PointInterruption, _InterventionMixin):
@@ -514,4 +520,6 @@ class DynamicIntervention(DynamicInterruption, _InterventionMixin):
             # This implies an infinite number of applications, but we don't support that yet, as we need some way
             #  of disabling a dynamic event proc for some time epsilon after it is triggered each time, otherwise
             #  it will just repeatedly trigger and the sim won't advance.
-            raise NotImplementedError("More than one application is not yet implemented.")
+            raise NotImplementedError(
+                "More than one application is not yet implemented."
+            )

--- a/causal_pyro/dynamical/ops.py
+++ b/causal_pyro/dynamical/ops.py
@@ -129,8 +129,7 @@ def simulate_span(
 @functools.singledispatch
 @pyro.poutine.runtime.effectful(type="apply_interruptions")
 def apply_interruptions(
-    dynamics: Dynamics[S, T],
-    start_state: State[T]
+    dynamics: Dynamics[S, T], start_state: State[T]
 ) -> Tuple[Dynamics[S, T], State[T]]:
     """
     Apply the effects of an interruption to a dynamical system.

--- a/tests/dynamical/dynamical_fixtures.py
+++ b/tests/dynamical/dynamical_fixtures.py
@@ -9,7 +9,7 @@ import causal_pyro
 from causal_pyro.dynamical.handlers import (
     ODEDynamics,
     PointInterruption,
-    PointIntervention
+    PointIntervention,
 )
 from causal_pyro.dynamical.ops import State, Trajectory, simulate
 

--- a/tests/dynamical/test_dynamic_interventions.py
+++ b/tests/dynamical/test_dynamic_interventions.py
@@ -18,9 +18,9 @@ from causal_pyro.dynamical.handlers import (
 from causal_pyro.dynamical.ops import State, Trajectory, simulate
 
 from .dynamical_fixtures import (
+    SimpleSIRDynamics,
     check_trajectories_match,
     check_trajectories_match_in_all_but_values,
-    SimpleSIRDynamics,
 )
 
 logger = logging.getLogger(__name__)
@@ -79,4 +79,7 @@ def test_dynamic_intervention_causes_change(
 
     # Make sure all points after the intervention include the added population.
     # noinspection PyTypeChecker
-    assert torch.all(postint_traj.S + postint_traj.I + postint_traj.R > (preint_total + intervene_state.S) * 0.95)
+    assert torch.all(
+        postint_traj.S + postint_traj.I + postint_traj.R
+        > (preint_total + intervene_state.S) * 0.95
+    )

--- a/tests/dynamical/test_noop_interruptions.py
+++ b/tests/dynamical/test_noop_interruptions.py
@@ -1,10 +1,8 @@
 import logging
 
-import causal_pyro
 import pyro
 import pytest
 import torch
-
 from pyro.distributions import Normal, Uniform, constraints
 
 import causal_pyro

--- a/tests/dynamical/test_static_interventions.py
+++ b/tests/dynamical/test_static_interventions.py
@@ -1,25 +1,16 @@
 import logging
 
-import causal_pyro
 import pyro
 import pytest
 import torch
-
 from pyro.distributions import Normal, Uniform, constraints
 
-
-import pyro
-import torch
-from pyro.distributions import constraints
 import causal_pyro
-
-from causal_pyro.dynamical.ops import State, simulate, Trajectory
 from causal_pyro.dynamical.handlers import (
     ODEDynamics,
     PointInterruption,
     PointIntervention,
     SimulatorEventLoop,
-    PointIntervention,
     simulate,
 )
 from causal_pyro.dynamical.ops import State, Trajectory, simulate


### PR DESCRIPTION
This WIP PR implements dynamic interventions via a refactor of the simulation event loop and the way interruption handlers accrue. This also serves to abstract solver idiosyncrasies behind a `simulate_to_interruption` operation that should work for solvers generally.

It is running but only has a single, simple test case as of now.