### PR TITLE
Add broadcasting test cases for indexed

### DIFF
--- a/tests/indexed/test_internals.py
+++ b/tests/indexed/test_internals.py
@@ -1,4 +1,5 @@
 import contextlib
+import itertools
 import logging
 
 import pyro.distributions as dist
@@ -19,6 +20,20 @@ from causal_pyro.indexed.ops import (
 
 logger = logging.getLogger(__name__)
 
+ENUM_SHAPES = [
+    (),
+    (2,),
+    (2, 1),
+    (2, 3),
+]
+
+PLATE_SHAPES = [
+    (),
+    (2,),
+    (2, 1),
+    (2, 3),
+    (1, 3),
+]
 
 BATCH_SHAPES = [
     (2,),
@@ -46,59 +61,59 @@ EVENT_SHAPES = [
     (2, 3, 2),
 ]
 
+SHAPE_CASES = list(
+    itertools.product(ENUM_SHAPES, PLATE_SHAPES, BATCH_SHAPES, EVENT_SHAPES)
+)
 
-@pytest.mark.parametrize("batch_shape", BATCH_SHAPES, ids=str)
-@pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
-@pytest.mark.parametrize("num_named", [0, 1, 2, 3])
-@pytest.mark.parametrize("first_available_dim", [-1, -2, -3])
-def test_indices_of_tensor(batch_shape, event_shape, num_named, first_available_dim):
+
+@pytest.mark.parametrize(
+    "enum_shape,plate_shape,batch_shape,event_shape", SHAPE_CASES, ids=str
+)
+def test_indices_of_tensor(enum_shape, plate_shape, batch_shape, event_shape):
     batch_dim_names = {
-        f"b{i}": first_available_dim - i
-        for i in range(min(num_named, len(batch_shape)))
-        if len(batch_shape) >= i - first_available_dim
+        f"b{i}": -1 - i
+        for i in range(len(plate_shape), len(plate_shape) + len(batch_shape))
     }
 
-    value = torch.randn(batch_shape + event_shape)
+    full_batch_shape = enum_shape + batch_shape + plate_shape
+    value = torch.randn(full_batch_shape + event_shape)
     actual_world = indices_of(
         value, event_dim=len(event_shape), name_to_dim=batch_dim_names
     )
 
     expected_world = IndexSet(
         **{
-            name: set(range(batch_shape[dim]))
+            name: set(range(full_batch_shape[dim]))
             for name, dim in batch_dim_names.items()
-            if batch_shape[dim] > 1
+            if full_batch_shape[dim] > 1
         }
     )
 
     assert actual_world == expected_world
 
 
-@pytest.mark.parametrize("batch_shape", BATCH_SHAPES, ids=str)
-@pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
-@pytest.mark.parametrize("num_named", [0, 1, 2, 3])
-@pytest.mark.parametrize("first_available_dim", [-1, -2, -3])
-def test_indices_of_distribution(
-    batch_shape, event_shape, num_named, first_available_dim
-):
+@pytest.mark.parametrize(
+    "enum_shape,plate_shape,batch_shape,event_shape", SHAPE_CASES, ids=str
+)
+def test_indices_of_distribution(enum_shape, plate_shape, batch_shape, event_shape):
     batch_dim_names = {
-        f"b{i}": first_available_dim - i
-        for i in range(min(num_named, len(batch_shape)))
-        if len(batch_shape) >= i - first_available_dim
+        f"b{i}": -1 - i
+        for i in range(len(plate_shape), len(plate_shape) + len(batch_shape))
     }
 
+    full_batch_shape = enum_shape + batch_shape + plate_shape
     value = (
-        dist.Normal(0, 1).expand(batch_shape + event_shape).to_event(len(event_shape))
+        dist.Normal(0, 1)
+        .expand(full_batch_shape + event_shape)
+        .to_event(len(event_shape))
     )
-    actual_world = indices_of(
-        value, event_dim=len(event_shape), name_to_dim=batch_dim_names
-    )
+    actual_world = indices_of(value, name_to_dim=batch_dim_names)
 
     expected_world = IndexSet(
         **{
-            name: set(range(batch_shape[dim]))
+            name: set(range(full_batch_shape[dim]))
             for name, dim in batch_dim_names.items()
-            if batch_shape[dim] > 1
+            if full_batch_shape[dim] > 1
         }
     )
 
@@ -106,20 +121,22 @@ def test_indices_of_distribution(
 
 
 # Test the law `gather(value, world) == value[indexset_as_mask(world)]`
-@pytest.mark.parametrize("batch_shape", BATCH_SHAPES, ids=str)
-@pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
-@pytest.mark.parametrize("cf_dim", [-1])
+@pytest.mark.parametrize(
+    "enum_shape,plate_shape,batch_shape,event_shape", SHAPE_CASES, ids=str
+)
 @pytest.mark.parametrize("use_effect", [True, False])
-def test_gather_tensor(batch_shape, event_shape, cf_dim, use_effect):
+def test_gather_tensor(enum_shape, plate_shape, batch_shape, event_shape, use_effect):
+    cf_dim = -1 - len(plate_shape)
     name_to_dim = {f"dim_{i}": cf_dim - i for i in range(len(batch_shape))}
 
-    value = torch.randn(batch_shape + event_shape)
+    full_batch_shape = enum_shape + batch_shape + plate_shape
+    value = torch.randn(full_batch_shape + event_shape)
 
     world = IndexSet(
         **{
-            name: {batch_shape[dim] - 2}
+            name: {full_batch_shape[dim] - 2}
             for name, dim in name_to_dim.items()
-            if batch_shape[dim] > 1
+            if full_batch_shape[dim] > 1
         }
     )
 
@@ -127,7 +144,9 @@ def test_gather_tensor(batch_shape, event_shape, cf_dim, use_effect):
         if use_effect:
             stack.enter_context(IndexPlatesMessenger(cf_dim))
             for name, dim in name_to_dim.items():
-                add_indices(IndexSet(**{name: set(range(max(2, batch_shape[dim])))}))
+                add_indices(
+                    IndexSet(**{name: set(range(max(2, full_batch_shape[dim])))})
+                )
             _name_to_dim = None
         else:
             _name_to_dim = name_to_dim
@@ -140,7 +159,7 @@ def test_gather_tensor(batch_shape, event_shape, cf_dim, use_effect):
         world,
         event_dim=len(event_shape),
         name_to_dim_size={
-            name: (dim, batch_shape[dim]) for name, dim in name_to_dim.items()
+            name: (dim, full_batch_shape[dim]) for name, dim in name_to_dim.items()
         },
     )
     _, mask = torch.broadcast_tensors(value, mask)
@@ -152,20 +171,24 @@ def test_gather_tensor(batch_shape, event_shape, cf_dim, use_effect):
     assert (actual.reshape((-1,) + event_shape) == expected).all()
 
 
-@pytest.mark.parametrize("batch_shape", BATCH_SHAPES, ids=str)
-@pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
-@pytest.mark.parametrize("cf_dim", [-1], ids=str)
+@pytest.mark.parametrize(
+    "enum_shape,plate_shape,batch_shape,event_shape", SHAPE_CASES, ids=str
+)
 @pytest.mark.parametrize("use_effect", [True, False])
-def test_scatter_tensor(batch_shape, event_shape, cf_dim, use_effect):
+def test_scatter_tensor(enum_shape, plate_shape, batch_shape, event_shape, use_effect):
+    cf_dim = -1 - len(plate_shape)
     name_to_dim = {f"dim_{i}": cf_dim - i for i in range(len(batch_shape))}
 
-    value = torch.randn((1,) * len(batch_shape) + event_shape)
+    full_batch_shape = enum_shape + batch_shape + plate_shape
+    value = torch.randn(
+        enum_shape + (1,) * len(batch_shape) + plate_shape + event_shape
+    )
 
     world = IndexSet(
         **{
-            name: {batch_shape[dim] - 2}
+            name: {full_batch_shape[dim] - 2}
             for name, dim in name_to_dim.items()
-            if batch_shape[dim] > 1
+            if full_batch_shape[dim] > 1
         }
     )
 
@@ -173,12 +196,14 @@ def test_scatter_tensor(batch_shape, event_shape, cf_dim, use_effect):
         if use_effect:
             stack.enter_context(IndexPlatesMessenger(cf_dim))
             for name, dim in name_to_dim.items():
-                add_indices(IndexSet(**{name: set(range(max(2, batch_shape[dim])))}))
+                add_indices(
+                    IndexSet(**{name: set(range(max(2, full_batch_shape[dim])))})
+                )
             _name_to_dim = None
         else:
             _name_to_dim = name_to_dim
 
-        actual = torch.zeros(batch_shape + event_shape)
+        actual = torch.zeros(full_batch_shape + event_shape)
         actual = scatter(
             value,
             world,
@@ -191,7 +216,7 @@ def test_scatter_tensor(batch_shape, event_shape, cf_dim, use_effect):
         world,
         event_dim=len(event_shape),
         name_to_dim_size={
-            name: (dim, batch_shape[dim]) for name, dim in name_to_dim.items()
+            name: (dim, full_batch_shape[dim]) for name, dim in name_to_dim.items()
         },
     )
     _, mask = torch.broadcast_tensors(value, mask)
@@ -202,20 +227,24 @@ def test_scatter_tensor(batch_shape, event_shape, cf_dim, use_effect):
     assert (actual == expected).all()
 
 
-@pytest.mark.parametrize("batch_shape", BATCH_SHAPES, ids=str)
-@pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
-@pytest.mark.parametrize("cf_dim", [-1], ids=str)
+@pytest.mark.parametrize(
+    "enum_shape,plate_shape,batch_shape,event_shape", SHAPE_CASES, ids=str
+)
 @pytest.mark.parametrize("use_effect", [True, False])
-def test_scatter_gather_tensor(batch_shape, event_shape, cf_dim, use_effect):
+def test_scatter_gather_tensor(
+    enum_shape, plate_shape, batch_shape, event_shape, use_effect
+):
+    cf_dim = -1 - len(plate_shape)
     name_to_dim = {f"dim_{i}": cf_dim - i for i in range(len(batch_shape))}
 
-    value = torch.randn(batch_shape + event_shape)
+    full_batch_shape = enum_shape + batch_shape + plate_shape
+    value = torch.randn(full_batch_shape + event_shape)
 
     world = IndexSet(
         **{
-            name: {batch_shape[dim] - 2}
+            name: {full_batch_shape[dim] - 2}
             for name, dim in name_to_dim.items()
-            if batch_shape[dim] > 1
+            if full_batch_shape[dim] > 1
         }
     )
 
@@ -223,7 +252,9 @@ def test_scatter_gather_tensor(batch_shape, event_shape, cf_dim, use_effect):
         if use_effect:
             stack.enter_context(IndexPlatesMessenger(cf_dim))
             for name, dim in name_to_dim.items():
-                add_indices(IndexSet(**{name: set(range(max(2, batch_shape[dim])))}))
+                add_indices(
+                    IndexSet(**{name: set(range(max(2, full_batch_shape[dim])))})
+                )
             _name_to_dim = None
         else:
             _name_to_dim = name_to_dim
@@ -234,7 +265,7 @@ def test_scatter_gather_tensor(batch_shape, event_shape, cf_dim, use_effect):
         actual = scatter(
             actual,
             world,
-            result=value.new_zeros(batch_shape + event_shape),
+            result=value.new_zeros(full_batch_shape + event_shape),
             event_dim=len(event_shape),
             name_to_dim=_name_to_dim,
         )
@@ -243,7 +274,7 @@ def test_scatter_gather_tensor(batch_shape, event_shape, cf_dim, use_effect):
         world,
         event_dim=len(event_shape),
         name_to_dim_size={
-            name: (dim, batch_shape[dim]) for name, dim in name_to_dim.items()
+            name: (dim, full_batch_shape[dim]) for name, dim in name_to_dim.items()
         },
     )
     _, mask = torch.broadcast_tensors(value, mask)
@@ -253,20 +284,26 @@ def test_scatter_gather_tensor(batch_shape, event_shape, cf_dim, use_effect):
     assert not (actual == expected)[~mask].any()
 
 
-@pytest.mark.parametrize("batch_shape", BATCH_SHAPES, ids=str)
-@pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
-@pytest.mark.parametrize("cf_dim", [-1], ids=str)
+@pytest.mark.parametrize(
+    "enum_shape,plate_shape,batch_shape,event_shape", SHAPE_CASES, ids=str
+)
 @pytest.mark.parametrize("use_effect", [True, False])
-def test_gather_scatter_tensor(batch_shape, event_shape, cf_dim, use_effect):
+def test_gather_scatter_tensor(
+    enum_shape, plate_shape, batch_shape, event_shape, use_effect
+):
+    cf_dim = -1 - len(plate_shape)
     name_to_dim = {f"dim_{i}": cf_dim - i for i in range(len(batch_shape))}
 
-    value = torch.randn((1,) * len(batch_shape) + event_shape)
+    full_batch_shape = enum_shape + batch_shape + plate_shape
+    value = torch.randn(
+        enum_shape + (1,) * len(batch_shape) + plate_shape + event_shape
+    )
 
     world = IndexSet(
         **{
-            name: {batch_shape[dim] - 1}
+            name: {full_batch_shape[dim] - 1}
             for name, dim in name_to_dim.items()
-            if batch_shape[dim] > 1
+            if full_batch_shape[dim] > 1
         }
     )
 
@@ -274,12 +311,14 @@ def test_gather_scatter_tensor(batch_shape, event_shape, cf_dim, use_effect):
         if use_effect:
             stack.enter_context(IndexPlatesMessenger(cf_dim))
             for name, dim in name_to_dim.items():
-                add_indices(IndexSet(**{name: set(range(max(2, batch_shape[dim])))}))
+                add_indices(
+                    IndexSet(**{name: set(range(max(2, full_batch_shape[dim])))})
+                )
             _name_to_dim = None
         else:
             _name_to_dim = name_to_dim
 
-        actual = torch.zeros(batch_shape + event_shape)
+        actual = torch.zeros(full_batch_shape + event_shape)
         actual = scatter(
             value,
             world,
@@ -295,15 +334,17 @@ def test_gather_scatter_tensor(batch_shape, event_shape, cf_dim, use_effect):
     assert (actual == expected).all()
 
 
-@pytest.mark.parametrize("batch_shape", BATCH_SHAPES, ids=str)
-@pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
-def test_scatter_broadcast_new(batch_shape, event_shape):
-    value1 = torch.randn(batch_shape + event_shape)
-    value2 = torch.randn(batch_shape + event_shape)
+@pytest.mark.parametrize(
+    "enum_shape,plate_shape,batch_shape,event_shape", SHAPE_CASES, ids=str
+)
+def test_scatter_broadcast_new(enum_shape, plate_shape, batch_shape, event_shape):
+    full_batch_shape = enum_shape + (1,) + batch_shape + plate_shape
+    value1 = torch.randn(full_batch_shape + event_shape)
+    value2 = torch.randn(full_batch_shape + event_shape)
 
-    name_to_dim = {"new_dim": -len(batch_shape) - 1}
+    name_to_dim = {"new_dim": -len(batch_shape) - len(plate_shape) - 1}
     ind1, ind2 = IndexSet(new_dim={0}), IndexSet(new_dim={1})
-    result = torch.zeros((2,) + batch_shape + event_shape)
+    result = torch.zeros(enum_shape + (2,) + batch_shape + plate_shape + event_shape)
 
     actual = scatter(
         value1, ind1, result=result, event_dim=len(event_shape), name_to_dim=name_to_dim
@@ -315,29 +356,33 @@ def test_scatter_broadcast_new(batch_shape, event_shape):
     actual1 = gather(actual, ind1, event_dim=len(event_shape), name_to_dim=name_to_dim)
     actual2 = gather(actual, ind2, event_dim=len(event_shape), name_to_dim=name_to_dim)
 
-    assert actual.shape == (2,) + batch_shape + event_shape
-    assert actual1.shape == (1,) + batch_shape + event_shape
-    assert actual2.shape == (1,) + batch_shape + event_shape
+    assert actual.shape == enum_shape + (2,) + batch_shape + plate_shape + event_shape
+    assert actual1.shape == enum_shape + (1,) + batch_shape + plate_shape + event_shape
+    assert actual2.shape == enum_shape + (1,) + batch_shape + plate_shape + event_shape
 
     assert (actual1 == value1).all()
     assert (actual2 == value2).all()
 
 
-@pytest.mark.parametrize("batch_shape", BATCH_SHAPES, ids=str)
-@pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
-def test_persistent_index_state(batch_shape, event_shape):
-    cf_dim = -1
+@pytest.mark.parametrize(
+    "enum_shape,plate_shape,batch_shape,event_shape", SHAPE_CASES, ids=str
+)
+def test_persistent_index_state(enum_shape, plate_shape, batch_shape, event_shape):
+    cf_dim = -1 - len(plate_shape)
     event_dim = len(event_shape)
+
     ind1, ind2 = IndexSet(new_dim={0}), IndexSet(new_dim={1})
-    result = torch.zeros((2,) + batch_shape + event_shape)
+    result = torch.zeros(enum_shape + (2,) + batch_shape + plate_shape + event_shape)
     name_to_dim = {f"dim_{i}": cf_dim - i for i in range(len(batch_shape))}
 
-    value1 = torch.randn(batch_shape + event_shape)
-    value2 = torch.randn(batch_shape + event_shape)
+    value1 = torch.randn(enum_shape + (1,) + batch_shape + plate_shape + event_shape)
+    value2 = torch.randn(enum_shape + (1,) + batch_shape + plate_shape + event_shape)
 
     with IndexPlatesMessenger(cf_dim) as index_state:
         for name, dim in name_to_dim.items():
-            add_indices(IndexSet(**{name: set(range(max(2, batch_shape[dim])))}))
+            add_indices(
+                IndexSet(**{name: set(range(max(2, (batch_shape + plate_shape)[dim])))})
+            )
 
     with index_state:
         actual = scatter(


### PR DESCRIPTION
Addresses #165 

This PR slightly refactors and generalizes the current `indexed` unit tests and adds test cases that model interactions between these operations and Pyro broadcasting.