### PR TITLE
Fixed symbolic link in tutorial

### DIFF
--- a/docs/source/tutorial_i.ipynb
+++ b/docs/source/tutorial_i.ipynb
@@ -32,7 +32,7 @@
     "    - [Simulating Observational Data](#simulating-observational-data-with-fixed-parameters)\n",
     "    - [Applying an Intervention](#applying-an-intervention)\n",
     "    - [Simulating Interventional Data](#simulating-interventional-data-with-fixed-parameters)\n",
-    "    - [Transforming Causal Models using ChiRho](#transforming-causal-models-using-causal-pyro---do)\n",
+    "    - [Transforming Causal Models using ChiRho](#transforming-causal-models-using-ChiRho---do)\n",
     "- [Observation 2: Causal Uncertainty is Probabilistic Uncertainty](#observation-2:-causal-uncertainty-is-probabilistic-uncertainty)\n",
     "    - [Adding Uncertainty over Model Parameters](#adding-uncertainty-over-model-parameters)\n",
     "    - [Simulating Observational Data with Uncertain Parameters](#simulating-observational-data-with-uncertain-parameters)\n",
@@ -365,7 +365,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![title](figures/Conditional_Distribution_of_Data.png)"
+    "![title](figures / Conditional_Distribution_of_Data.png)"
    ]
   },
   {
@@ -560,7 +560,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Transforming Causal Models using ChiRho - `do`"
+    "### Transforming Causal Models using ChiRho - `do`\n"
    ]
   },
   {
@@ -640,7 +640,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![title](figures/Interventional_Conditional.png)"
+    "![title](figures / Interventional_Conditional.png)"
    ]
   },
   {
@@ -1515,7 +1515,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![title](figures/Interventional_Marginal.png)"
+    "![title](figures / Interventional_Marginal.png)"
    ]
   },
   {
@@ -1828,7 +1828,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![title](figures/Interventional_Posterior.png)"
+    "![title](figures / Interventional_Posterior.png)"
    ]
   },
   {

--- a/docs/source/tutorial_i.ipynb
+++ b/docs/source/tutorial_i.ipynb
@@ -365,7 +365,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![title](figures / Conditional_Distribution_of_Data.png)"
+    "![title](figures/Conditional_Distribution_of_Data.png)"
    ]
   },
   {
@@ -640,7 +640,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![title](figures / Interventional_Conditional.png)"
+    "![title](figures/Interventional_Conditional.png)"
    ]
   },
   {
@@ -1515,7 +1515,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![title](figures / Interventional_Marginal.png)"
+    "![title](figures/Interventional_Marginal.png)"
    ]
   },
   {
@@ -1828,7 +1828,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![title](figures / Interventional_Posterior.png)"
+    "![title](figures/Interventional_Posterior.png)"
    ]
   },
   {

--- a/docs/source/tutorial_i.ipynb
+++ b/docs/source/tutorial_i.ipynb
@@ -560,7 +560,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Transforming Causal Models using ChiRho - `do`\n"
+    "### Transforming Causal Models using ChiRho - `do`"
    ]
   },
   {


### PR DESCRIPTION
In #192 we missed one of the symbolic links in the glossary, leading to a dead link. This extremely minimal PR fixes that link by renaming the reference.