### PR TITLE
Fix Gradient Propagation Through Dynamic Interventions

### DIFF
--- a/chirho/dynamical/handlers.py
+++ b/chirho/dynamical/handlers.py
@@ -255,7 +255,9 @@ def torchdiffeq_ode_simulate_to_interruption(
         triggered_events.append(next_static_interruption)
 
     # Construct a new timespan that cuts off measurements after the event fires, but that includes the event time.
-    timespan_2nd_pass = torch.cat((timespan[timespan < event_time], event_time.unsqueeze(0)))
+    timespan_2nd_pass = torch.cat(
+        (timespan[timespan < event_time], event_time.unsqueeze(0))
+    )
 
     # Execute a standard, non-event based simulation on the new timespan.
     trajectory = simulate(dynamics, start_state, timespan_2nd_pass, **kwargs)
@@ -402,7 +404,7 @@ class SimulatorEventLoop(Generic[T], pyro.poutine.messenger.Messenger):
                     # We just pass nothing here, as any interruption handlers will be responsible for
                     #  accruing themselves to the message. Leaving explicit for documentation.
                     dynamic_interruptions=None,
-                )  # type: Trajectory[T], Tuple['Interruption', ...], float, State[T]
+                )  # type: Trajectory[T], Tuple['Interruption', ...], torch.Tensor, State[T]
 
             if len(terminal_interruptions) > 1:
                 warnings.warn(

--- a/chirho/dynamical/handlers.py
+++ b/chirho/dynamical/handlers.py
@@ -255,7 +255,7 @@ def torchdiffeq_ode_simulate_to_interruption(
         triggered_events.append(next_static_interruption)
 
     # Construct a new timespan that cuts off measurements after the event fires, but that includes the event time.
-    timespan_2nd_pass = torch.tensor([*timespan[timespan < event_time], event_time])
+    timespan_2nd_pass = torch.cat((timespan[timespan < event_time], event_time.unsqueeze(0)))
 
     # Execute a standard, non-event based simulation on the new timespan.
     trajectory = simulate(dynamics, start_state, timespan_2nd_pass, **kwargs)
@@ -438,8 +438,8 @@ class SimulatorEventLoop(Generic[T], pyro.poutine.messenger.Messenger):
             # Construct the next timespan so that we simulate from the prevous interruption time.
             # TODO AZ — we should be able to detect when this eps is too small, as it will repeatedly trigger
             #  the same event at the same time.
-            span_timespan = torch.tensor(
-                [end_time, *full_timespan[full_timespan > end_time]]
+            span_timespan = torch.cat(
+                (end_time.unsqueeze(0), full_timespan[full_timespan > end_time])
             )
 
             # Update the starting state.

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -185,7 +185,7 @@ def simulate_to_interruption(
     next_static_interruption: Optional["PointInterruption"] = None,
     dynamic_interruptions: Optional[List["DynamicInterruption"]] = None,
     **kwargs,
-) -> Tuple[Trajectory[T], Tuple["Interruption", ...], float, State[T]]:
+) -> Tuple[Trajectory[T], Tuple["Interruption", ...], T, State[T]]:
     """
     Simulate a dynamical system until the next interruption. Return the state at the requested time points, and
      a collection of interruptions that ended the simulation (this will usually just be a single interruption).


### PR DESCRIPTION
This was not working b/c timespans were being spliced with `torch.tensor` (which apparently clears out gradients) instead of `torch.cat` which preserves them. Two tests added — one of the behind-the-scenes torchdiffeq functionality, and another doing the exact same thing but using `DynamicIntervention`.

Note that gradients do not propagate through the `PointIntervention` `time` argument. I added a test for this but marked it as skipped for now. Added issue #228 to track this.