### PR TITLE
Add cut and examples to Sphinx docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,6 +129,10 @@ approximations that power much of the modern probabilistic machine learning land
   - Counterfactuals with normalizing flows
 - `Example: Structured Latent Confounders <https://basisresearch.github.io/chirho/slc.html>`_
   - Causal effect estimation when latent confounders are shared across groups
+- `Example: Synthetic difference-in-differences <https://basisresearch.github.io/chirho/sdid.html>`_
+  - Counterfactual estimation from longitudinal data
+- `Example: Robust estimation with the DR learner <https://basisresearch.github.io/chirho/dr_learner.html>`_
+  - Heterogeneous causal effect estimation with a misspecified model
 - `Design notes <https://basisresearch.github.io/chirho/design_notes>`_
   - Technical implementation details of ChiRho using effect handlers
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,6 +27,8 @@ Table of Contents
    deepscm
    slc
    mediation
+   sdid
+   dr_learner
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/observational.rst
+++ b/docs/source/observational.rst
@@ -27,6 +27,10 @@ Handlers
    :members:
    :undoc-members:
 
+.. automodule:: chirho.observational.handlers.cut
+   :members:
+   :undoc-members:
+
 Internals
 ---------
 


### PR DESCRIPTION
This PR makes the examples and library code from #229 show up in the ChiRho documentation