### PR TITLE
Add a BiasedPreemptions handler

### DIFF
--- a/chirho/counterfactual/handlers/counterfactual.py
+++ b/chirho/counterfactual/handlers/counterfactual.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Generic, Mapping, TypeVar
+from typing import Any, Dict, Generic, Mapping, Tuple, TypeVar
 
 import pyro
 import torch
@@ -30,6 +30,9 @@ class BaseCounterfactualMessenger(FactualConditioningMessenger):
     @staticmethod
     def _pyro_preempt(msg: Dict[str, Any]) -> None:
         obs, acts, case = msg["args"]
+        if case is not None:
+            return
+
         msg["kwargs"]["name"] = f"__split_{msg['name']}"
         case_dist = pyro.distributions.Categorical(torch.ones(len(acts) + 1))
         case = pyro.sample(msg["kwargs"]["name"], case_dist.mask(False), obs=case)
@@ -119,4 +122,78 @@ class Preemptions(Generic[T], pyro.poutine.messenger.Messenger):
             None,
             event_dim=len(msg["fn"].event_shape),
             name=msg["name"],
+        )
+
+
+class BiasedPreemptions(pyro.poutine.messenger.Messenger):
+    """
+    Effect handler that applies the operation :func:`~chirho.counterfactual.ops.preempt`
+    to sample sites in a probabilistic program,
+    similar to the handler :func:`~chirho.observational.handlers.condition`
+    for :func:`~chirho.observational.ops.observe` .
+    or the handler :func:`~chirho.interventional.handlers.do`
+    for :func:`~chirho.interventional.ops.intervene` .
+
+    See the documentation for :func:`~chirho.counterfactual.ops.preempt` for more details.
+
+    This handler introduces an auxiliary discrete random variable at each preempted sample site
+    whose name is the name of the sample site prefixed by ``prefix``, and
+    whose value is used as the ``case`` argument to :func:`preempt`,
+    to determine whether the preemption returns the present value of the site
+    or the new value specified for the site in ``actions``
+
+    The distributions of the auxiliary discrete random variables are parameterized by ``bias``.
+    By default, ``bias == 0`` and the value returned by the sample site is equally likely
+    to be the factual case (i.e. the present value of the site) or one of the counterfactual cases
+    (i.e. the new value(s) specified for the site in ``actions``).
+    When ``0 < bias <= 0.5``, the preemption is less than equally likely to occur.
+    When ``-0.5 <= bias < 0``, the preemption is more than equally likely to occur.
+
+    More specifically, the probability of the factual case is ``0.5 - bias``,
+    and the probability of each counterfactual case is ``(0.5 + bias) / num_actions``,
+    where ``num_actions`` is the number of counterfactual actions for the sample site (usually 1).
+
+    :param actions: A mapping from sample site names to interventions.
+    :param bias: The scalar bias towards the factual case. Must be between -0.5 and 0.5.
+    :param prefix: The prefix for naming the auxiliary discrete random variables.
+    """
+
+    actions: Mapping[str, Intervention[torch.Tensor]]
+    bias: float
+    prefix: str
+
+    def __init__(
+        self,
+        actions: Mapping[str, Intervention[torch.Tensor]],
+        *,
+        bias: float = 0.0,
+        prefix: str = "__witness_split_",
+    ):
+        assert -0.5 <= bias <= 0.5, "bias must be between -0.5 and 0.5"
+        self.actions = actions
+        self.bias = bias
+        self.prefix = prefix
+        super().__init__()
+
+    def _pyro_post_sample(self, msg):
+        try:
+            action = self.actions[msg["name"]]
+        except KeyError:
+            return
+
+        action = (action,) if not isinstance(action, tuple) else action
+        num_actions = len(action) if isinstance(action, tuple) else 1
+        weights = torch.tensor(
+            [0.5 - self.bias] + ([(0.5 + self.bias) / num_actions] * num_actions),
+            device=msg["value"].device,
+        )
+        case_dist = pyro.distributions.Categorical(probs=weights)
+        case = pyro.sample(f"{self.prefix}{msg['name']}", case_dist)
+
+        msg["value"] = preempt(
+            msg["value"],
+            action,
+            case,
+            event_dim=len(msg["fn"].event_shape),
+            name=f"{self.prefix}{msg['name']}",
         )


### PR DESCRIPTION
Part of modularizing #236 

This PR adds a new effect handler `BiasedPreemptions` for inserting `chirho.counterfactual.ops.preempt` calls after `pyro.sample` calls. Unlike `Preemptions`, this handler flips a possibly unfair coin to decide whether or not an intervention takes place.

There are also some minor changes to the organization of default `preempt` behavior across `chirho.counterfactual.handlers.MultiWorldCounterfactual` and `chirho.counterfactual.handlers.counterfactual.Preemptions`.

Tested:
- Added a test case to existing `Preemptions` unit test