### PR TITLE
fixed test to reflect PyroModule changes

### DIFF
--- a/tests/dynamical/test_static_observation.py
+++ b/tests/dynamical/test_static_observation.py
@@ -4,7 +4,6 @@ from contextlib import ExitStack
 import pyro
 import pytest
 import torch
-from pyro.infer import SVI, Trace_ELBO
 from pyro.infer.autoguide import AutoMultivariateNormal
 
 from chirho.dynamical.handlers import (
@@ -28,6 +27,7 @@ logger = logging.getLogger(__name__)
 # Global variables for tests
 init_state = State(S=torch.tensor(1.0), I=torch.tensor(2.0), R=torch.tensor(3.3))
 tspan = torch.tensor([0.0, 1.0, 2.0, 3.0, 4.0])
+
 
 def run_svi_inference(model, n_steps=10, verbose=False, lr=0.03, **model_kwargs):
     guide = AutoMultivariateNormal(model)
@@ -135,7 +135,7 @@ def test_svi_composition_test_one(model, obs_handler):
                 with _get_compatible_observations(obs_handler, time=2.9, data=data1):
                     traj = simulate(sir, init_state, tspan)
             return traj
-        
+
     conditioned_sir = ConditionedSIR()
 
     guide = run_svi_inference(conditioned_sir)
@@ -224,7 +224,7 @@ def test_svi_composition_test_multi_point_obs(model):
                         stack.enter_context(manager)
                     traj = simulate(sir, init_state, tspan)
             return traj
-        
+
     conditioned_sir = ConditionedSIR()
 
     guide = run_svi_inference(conditioned_sir)

--- a/tests/dynamical/test_static_observation.py
+++ b/tests/dynamical/test_static_observation.py
@@ -21,11 +21,29 @@ from .dynamical_fixtures import (
     check_trajectories_match,
 )
 
+pyro.settings.set(module_local_params=True)
+
 logger = logging.getLogger(__name__)
 
 # Global variables for tests
 init_state = State(S=torch.tensor(1.0), I=torch.tensor(2.0), R=torch.tensor(3.3))
 tspan = torch.tensor([0.0, 1.0, 2.0, 3.0, 4.0])
+
+def run_svi_inference(model, n_steps=10, verbose=False, lr=0.03, **model_kwargs):
+    guide = AutoMultivariateNormal(model)
+    elbo = pyro.infer.Trace_ELBO()(model, guide)
+    # initialize parameters
+    elbo(**model_kwargs)
+    adam = torch.optim.Adam(elbo.parameters(), lr=lr)
+    # Do gradient steps
+    for step in range(1, n_steps + 1):
+        adam.zero_grad()
+        loss = elbo(**model_kwargs)
+        loss.backward()
+        adam.step()
+        if (step % 250 == 0) or (step == 1) & verbose:
+            print("[iteration %04d] loss: %.4f" % (step, loss))
+    return guide
 
 
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
@@ -110,22 +128,19 @@ def test_svi_composition_test_one(model, obs_handler):
         "R_obs": torch.tensor(5.0),
     }
 
-    def conditioned_sir():
-        sir = model()
-        with SimulatorEventLoop():
-            with _get_compatible_observations(obs_handler, time=2.9, data=data1):
-                traj = simulate(sir, init_state, tspan)
-        return traj
+    class ConditionedSIR(pyro.nn.PyroModule):
+        def forward(self):
+            sir = model()
+            with SimulatorEventLoop():
+                with _get_compatible_observations(obs_handler, time=2.9, data=data1):
+                    traj = simulate(sir, init_state, tspan)
+            return traj
+        
+    conditioned_sir = ConditionedSIR()
 
-    guide = AutoMultivariateNormal(conditioned_sir)
-    adam = pyro.optim.Adam({"lr": 0.03})
-    svi = SVI(conditioned_sir, guide, adam, loss=Trace_ELBO())
-    n_steps = 2
+    guide = run_svi_inference(conditioned_sir)
 
-    # Do gradient steps
-    pyro.clear_param_store()
-    for step in range(n_steps):
-        svi.step()
+    assert guide is not None
 
 
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
@@ -195,29 +210,26 @@ def test_svi_composition_test_multi_point_obs(model):
     data[0] = [torch.tensor(0.1), data1]
     data[1] = [torch.tensor(3.1), data2]
 
-    def conditioned_sir(data):
-        sir = model()
-        observation_managers = []
-        for obs in data.values():
-            obs_time = obs[0].item()
-            obs_data = obs[1]
-            observation_managers.append(PointObservation(obs_time, obs_data))
-        with SimulatorEventLoop():
-            with ExitStack() as stack:
-                for manager in observation_managers:
-                    stack.enter_context(manager)
-                traj = simulate(sir, init_state, tspan)
-        return traj
+    class ConditionedSIR(pyro.nn.PyroModule):
+        def forward(self):
+            sir = model()
+            observation_managers = []
+            for obs in data.values():
+                obs_time = obs[0].item()
+                obs_data = obs[1]
+                observation_managers.append(PointObservation(obs_time, obs_data))
+            with SimulatorEventLoop():
+                with ExitStack() as stack:
+                    for manager in observation_managers:
+                        stack.enter_context(manager)
+                    traj = simulate(sir, init_state, tspan)
+            return traj
+        
+    conditioned_sir = ConditionedSIR()
 
-    guide = AutoMultivariateNormal(conditioned_sir)
-    adam = pyro.optim.Adam({"lr": 0.03})
-    svi = SVI(conditioned_sir, guide, adam, loss=Trace_ELBO())
-    n_steps = 25
+    guide = run_svi_inference(conditioned_sir)
 
-    # Do gradient steps
-    pyro.clear_param_store()
-    for step in range(n_steps):
-        svi.step(data)
+    assert guide is not None
 
 
 @pytest.mark.parametrize("model", [bayes_sir_model])
@@ -229,23 +241,19 @@ def test_svi_composition_vectorized_obs(model):
         "R_obs": torch.tensor([0.0, 1.0, 2.0, 3.0]),
     }
 
-    def conditioned_sir(times_data):
-        times, data = times_data
-        sir = model()
-        with SimulatorEventLoop():
-            with NonInterruptingPointObservationArray(times=times, data=data):
-                traj = simulate(sir, init_state, tspan)
-        return traj
+    class ConditionedSIR(pyro.nn.PyroModule):
+        def forward(self):
+            sir = model()
+            with SimulatorEventLoop():
+                with NonInterruptingPointObservationArray(times=times, data=data):
+                    traj = simulate(sir, init_state, tspan)
+            return traj
 
-    guide = AutoMultivariateNormal(conditioned_sir)
-    adam = pyro.optim.Adam({"lr": 0.03})
-    svi = SVI(conditioned_sir, guide, adam, loss=Trace_ELBO())
-    n_steps = 25
+    conditioned_sir = ConditionedSIR()
 
-    # Do gradient steps
-    pyro.clear_param_store()
-    for step in range(n_steps):
-        svi.step((times, data))
+    guide = run_svi_inference(conditioned_sir)
+
+    assert guide is not None
 
 
 @pytest.mark.parametrize("use_event_loop", [True, False])


### PR DESCRIPTION
This small PR modifies some dynamical systems tests to use the more modern `PyroModule` interface for specifying probabilistic/causal models in Pyro/ChiRho. This avoids bugs introduced by using the preferable `pyro.settings.set(module_local_params=True)` when using SVI.