### PR TITLE
Replace Preemptions handler implementation

### DIFF
--- a/chirho/counterfactual/handlers/counterfactual.py
+++ b/chirho/counterfactual/handlers/counterfactual.py
@@ -108,7 +108,7 @@ class Preemptions(Generic[T], pyro.poutine.messenger.Messenger):
     where ``num_actions`` is the number of counterfactual actions for the sample site (usually 1).
 
     :param actions: A mapping from sample site names to interventions.
-    :param bias: The scalar bias towards the factual case. Must be between -0.5 and 0.5.
+    :param bias: The scalar bias towards not intervening. Must be between -0.5 and 0.5.
     :param prefix: The prefix for naming the auxiliary discrete random variables.
     """
 

--- a/chirho/counterfactual/handlers/counterfactual.py
+++ b/chirho/counterfactual/handlers/counterfactual.py
@@ -29,16 +29,8 @@ class BaseCounterfactualMessenger(FactualConditioningMessenger):
 
     @staticmethod
     def _pyro_preempt(msg: Dict[str, Any]) -> None:
-        obs, acts, case = msg["args"]
         if msg["kwargs"].get("name", None) is None:
             msg["kwargs"]["name"] = msg["name"]
-
-        if case is not None:
-            return
-
-        case_dist = pyro.distributions.Categorical(torch.ones(len(acts) + 1))
-        case = pyro.sample(msg["name"], case_dist.mask(False), obs=case)
-        msg["args"] = (obs, acts, case)
 
 
 class SingleWorldCounterfactual(BaseCounterfactualMessenger):

--- a/tests/counterfactual/test_counterfactual_handler.py
+++ b/tests/counterfactual/test_counterfactual_handler.py
@@ -15,7 +15,7 @@ from chirho.counterfactual.handlers import (  # TwinWorldCounterfactual,
     SingleWorldFactual,
     TwinWorldCounterfactual,
 )
-from chirho.counterfactual.handlers.counterfactual import BiasedPreemptions, Preemptions
+from chirho.counterfactual.handlers.counterfactual import Preemptions
 from chirho.counterfactual.handlers.selection import SelectFactual
 from chirho.counterfactual.ops import preempt, split
 from chirho.indexed.ops import IndexSet, gather, indices_of, union
@@ -675,8 +675,7 @@ def test_preempt_op_singleworld():
 
 @pytest.mark.parametrize("cf_dim", [-2, -3, None])
 @pytest.mark.parametrize("event_shape", [(), (4,), (4, 3)])
-@pytest.mark.parametrize("use_biased_preemption", [False, True])
-def test_cf_handler_preemptions(cf_dim, event_shape, use_biased_preemption):
+def test_cf_handler_preemptions(cf_dim, event_shape):
     event_dim = len(event_shape)
 
     splits = {"x": torch.tensor(0.0)}
@@ -693,12 +692,9 @@ def test_cf_handler_preemptions(cf_dim, event_shape, use_biased_preemption):
         z = pyro.sample("z", dist.Normal(x + y, 1).to_event(len(event_shape)))
         return dict(w=w, x=x, y=y, z=z)
 
-    if use_biased_preemption:
-        preemption_handler = BiasedPreemptions(
-            actions=preemptions, bias=0.1, prefix="__split_"
-        )
-    else:
-        preemption_handler = Preemptions(actions=preemptions)
+    preemption_handler = Preemptions(
+        actions=preemptions, bias=0.1, prefix="__split_"
+    )
 
     with MultiWorldCounterfactual(cf_dim), preemption_handler:
         tr = pyro.poutine.trace(model).get_trace()

--- a/tests/counterfactual/test_counterfactual_handler.py
+++ b/tests/counterfactual/test_counterfactual_handler.py
@@ -692,9 +692,7 @@ def test_cf_handler_preemptions(cf_dim, event_shape):
         z = pyro.sample("z", dist.Normal(x + y, 1).to_event(len(event_shape)))
         return dict(w=w, x=x, y=y, z=z)
 
-    preemption_handler = Preemptions(
-        actions=preemptions, bias=0.1, prefix="__split_"
-    )
+    preemption_handler = Preemptions(actions=preemptions, bias=0.1, prefix="__split_")
 
     with MultiWorldCounterfactual(cf_dim), preemption_handler:
         tr = pyro.poutine.trace(model).get_trace()

--- a/tests/counterfactual/test_counterfactual_handler.py
+++ b/tests/counterfactual/test_counterfactual_handler.py
@@ -705,6 +705,16 @@ def test_cf_handler_preemptions(cf_dim, event_shape):
             x={0, 1}
         )
 
+    for k in preemptions.keys():
+        tst = tr.nodes[f"__split_{k}"]["value"]
+        assert torch.allclose(
+            tr.nodes[f"__split_{k}"]["fn"].log_prob(torch.tensor(0)).exp(),
+            torch.tensor(0.5 - 0.1),
+        )
+        tst_0 = (tst == 0).expand(tr.nodes[k]["fn"].batch_shape)
+        assert torch.all(tr.nodes[k]["value"][~tst_0] == preemptions[k])
+        assert torch.all(tr.nodes[k]["value"][tst_0] != preemptions[k])
+
 
 # Define a helper function to run SVI. (Generally, Pyro users like to have more control over the training process!)
 def run_svi_inference(model, n_steps=1000, verbose=True, lr=0.03, **model_kwargs):


### PR DESCRIPTION
This PR removes the original `Preemptions` handler added in #143 and replaces it with the renamed implementation of `BiasedPreemptions` from #239, which is equivalent when the bias parameter is set to its default value of 0.

`Preemptions` is currently not being used on `master` or in any of the latest causality code. It's also not clear to me when and how we would have used `Preemptions` in a way distinct from `BiasedPreemptions`, or that the approach in the original version of `Preemptions` of outsourcing default behavior for `preempt` was sensible to begin with.

Tested:
- Refactoring covered by existing unit tests