### PR TITLE
Removed pandoc dependency from docs build CI

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -15,10 +15,6 @@ jobs:
       pages: write
       id-token: write
     steps:
-    - id: pandoc-install
-      run: |
-        sudo apt install -y pandoc
-
     - id: deployment
       uses: sphinx-notes/pages@v3
       with:

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -15,6 +15,9 @@ jobs:
       pages: write
       id-token: write
     steps:
+    - id: pandoc-install
+      run: |
+        sudo apt install -y pandoc
 
     - id: deployment
       uses: sphinx-notes/pages@v3

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -15,9 +15,6 @@ jobs:
       pages: write
       id-token: write
     steps:
-    - id: pandoc-install
-      run: |
-        sudo apt install -y pandoc
 
     - id: deployment
       uses: sphinx-notes/pages@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,12 +42,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
-        run: |
-          sudo apt install -y pandoc
-          python -m pip install --upgrade pip
-          pip install .[test]
-
       - name: Test
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[test]
+
       - name: Test
         shell: bash
         run: |

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -6,3 +6,4 @@ sphinxcontrib-bibtex
 sphinx_rtd_theme
 myst_parser
 nbsphinx
+pypandoc-binary

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
             "sphinx_rtd_theme",
             "myst_parser",
             "nbsphinx",
+            "pypandoc-binary"
         ],
     },
     python_requires=">=3.8",


### PR DESCRIPTION
This tiny PR removes the unnecessary intallation of `pandoc` from the documentation CI build.

Closes #210 