### PR TITLE
pin sphinx version to 7.1.2 to fix docs building

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,7 +1,7 @@
 pyro-ppl>=1.8.5
 jupyter
 mypy
-sphinx==7.1.2
+sphinx==7.2.0
 sphinxcontrib-bibtex
 sphinx_rtd_theme
 myst_parser

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,7 +1,7 @@
 pyro-ppl>=1.8.5
 jupyter
 mypy
-sphinx==7.2.0
+sphinx==7.1.2
 sphinxcontrib-bibtex
 sphinx_rtd_theme
 myst_parser

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,7 +1,7 @@
 pyro-ppl>=1.8.5
 jupyter
 mypy
-sphinx
+sphinx==7.1.2
 sphinxcontrib-bibtex
 sphinx_rtd_theme
 myst_parser

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
             "sphinx_rtd_theme",
             "myst_parser",
             "nbsphinx",
-            "pypandoc-binary"
         ],
     },
     python_requires=">=3.8",

--- a/setup.py
+++ b/setup.py
@@ -50,11 +50,12 @@ setup(
             "black",
             "flake8",
             "isort",
-            "sphinx",
+            "sphinx==7.1.2",
             "sphinxcontrib-bibtex",
             "sphinx_rtd_theme",
             "myst_parser",
             "nbsphinx",
+            "pypandoc-binary"
         ],
     },
     python_requires=">=3.8",


### PR DESCRIPTION
Pinning sphinx to 7.1.2 (the version most recent version before docs failed to build after #238) appears to fix docs building locally.

Pinning sphinx to 7.2.0 (the next highest version) introduces errors as follows and fails to build docs:

Note, that this is only a partial error log, as the full log is too large.

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/sphinx/ext/autodoc/importer.py", line 64, in import_module
    return importlib.import_module(modname)
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/sam-basis/Desktop/Research/chirho/chirho/observational/__init__.py", line 1, in <module>
    import chirho.observational.internals  # noqa: F401
  File "/Users/sam-basis/Desktop/Research/chirho/chirho/observational/internals.py", line 3, in <module>
    import pyro
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/__init__.py", line 4, in <module>
    import pyro.poutine as poutine
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/poutine/__init__.py", line 4, in <module>
    from .handlers import (
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/poutine/handlers.py", line 58, in <module>
    from .block_messenger import BlockMessenger
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/poutine/block_messenger.py", line 6, in <module>
    from pyro.poutine.messenger import Messenger
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/poutine/messenger.py", line 7, in <module>
    from .runtime import _PYRO_STACK
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/poutine/runtime.py", line 7, in <module>
    from pyro.params.param_store import (  # noqa: F401
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/params/__init__.py", line 4, in <module>
    from .param_store import (
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/params/param_store.py", line 9, in <module>
    import torch
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/torch/__init__.py", line 457, in <module>
    for name in dir(_C):
NameError: name '_C' is not defined
```

Pinning sphinx to 7.2.5 produces similar error logs, but does build a version of the docs with some formatting missing:

```
Traceback (most recent call last):
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/sphinx/ext/autodoc/importer.py", line 90, in import_object
    module = import_module(modname, warningiserror=warningiserror)
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/sphinx/ext/autodoc/importer.py", line 69, in import_module
    raise ImportError(exc, traceback.format_exc()) from exc
ImportError: (RuntimeError("function '_has_torch_function' already has a docstring"), 'Traceback (most recent call last):\n  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/sphinx/ext/autodoc/importer.py", line 65, in import_module\n    return importlib.import_module(modname)\n  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/importlib/__init__.py", line 126, in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import\n  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load\n  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked\n  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked\n  File "<frozen importlib._bootstrap_external>", line 883, in exec_module\n  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed\n  File "/Users/sam-basis/Desktop/Research/chirho/chirho/observational/__init__.py", line 1, in <module>\n    import chirho.observational.internals  # noqa: F401\n  File "/Users/sam-basis/Desktop/Research/chirho/chirho/observational/internals.py", line 3, in <module>\n    import pyro\n  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/__init__.py", line 4, in <module>\n    import pyro.poutine as poutine\n  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/poutine/__init__.py", line 4, in <module>\n    from .handlers import (\n  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/poutine/handlers.py", line 58, in <module>\n    from .block_messenger import BlockMessenger\n  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/poutine/block_messenger.py", line 6, in <module>\n    from pyro.poutine.messenger import Messenger\n  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/poutine/messenger.py", line 7, in <module>\n    from .runtime import _PYRO_STACK\n  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/poutine/runtime.py", line 7, in <module>\n    from pyro.params.param_store import (  # noqa: F401\n  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/params/__init__.py", line 4, in <module>\n    from .param_store import (\n  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/params/param_store.py", line 9, in <module>\n    import torch\n  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/torch/__init__.py", line 933, in <module>\n    from ._tensor import Tensor\n  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/torch/_tensor.py", line 21, in <module>\n    from torch.overrides import (\n  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/torch/overrides.py", line 1565, in <module>\n    has_torch_function = _add_docstr(\nRuntimeError: function \'_has_torch_function\' already has a docstring\n')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/sphinx/ext/autodoc/importer.py", line 65, in import_module
    return importlib.import_module(modname)
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/sam-basis/Desktop/Research/chirho/chirho/observational/__init__.py", line 1, in <module>
    import chirho.observational.internals  # noqa: F401
  File "/Users/sam-basis/Desktop/Research/chirho/chirho/observational/internals.py", line 3, in <module>
    import pyro
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/__init__.py", line 4, in <module>
    import pyro.poutine as poutine
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/poutine/__init__.py", line 4, in <module>
    from .handlers import (
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/poutine/handlers.py", line 58, in <module>
    from .block_messenger import BlockMessenger
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/poutine/block_messenger.py", line 6, in <module>
    from pyro.poutine.messenger import Messenger
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/poutine/messenger.py", line 7, in <module>
    from .runtime import _PYRO_STACK
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/poutine/runtime.py", line 7, in <module>
    from pyro.params.param_store import (  # noqa: F401
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/params/__init__.py", line 4, in <module>
    from .param_store import (
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/pyro/params/param_store.py", line 9, in <module>
    import torch
  File "/Users/sam-basis/opt/anaconda3/envs/build_test/lib/python3.10/site-packages/torch/__init__.py", line 457, in <module>
    for name in dir(_C):
NameError: name '_C' is not defined

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... copying static files... done
copying extra files... done
done
writing output... [100%] tutorial_i
generating indices... genindex py-modindex done
copying linked files... 
copying notebooks ... [100%] tutorial_i.ipynb
highlighting module code... 
writing additional pages... search done
copying images... [100%] figures/Interventional_Posterior.png
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 20 warnings.
```