### PR TITLE
Fix docs deployment to GH-pages by pinning sphinx_rtd_theme to 1.3.0

### DIFF
--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -3,6 +3,6 @@ jupyter
 mypy
 sphinx==7.1.2
 sphinxcontrib-bibtex
-sphinx_rtd_theme
+sphinx_rtd_theme==1.3.0
 myst_parser
 nbsphinx

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
             "isort",
             "sphinx==7.1.2",
             "sphinxcontrib-bibtex",
-            "sphinx_rtd_theme",
+            "sphinx_rtd_theme==1.3.0",
             "myst_parser",
             "nbsphinx",
         ],


### PR DESCRIPTION
Resolves #243 

See #261 for evidence that this simple change fixes docs deployment.