### PR TITLE
Removed unused headers for counterfactual operations

### DIFF
--- a/docs/source/counterfactual.rst
+++ b/docs/source/counterfactual.rst
@@ -5,13 +5,6 @@ Counterfactual
    :members:
    :undoc-members:
 
-Operations
-----------
-
-.. automodule:: chirho.counterfactual.ops
-   :members:
-   :undoc-members:
-
 Handlers
 --------
 


### PR DESCRIPTION
addresses #269 

Building the docs locally with this change results in the following successfully built docs.
<img width="981" alt="Screenshot 2023-09-19 at 12 46 14 PM" src="https://github.com/BasisResearch/chirho/assets/13202375/54e62210-59a2-46c3-8755-ebaa98332059">
