### PR TITLE
Make example documentation headers consistently formatted

### DIFF
--- a/docs/source/backdoor.ipynb
+++ b/docs/source/backdoor.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Backdoor Adjustment Example"
+    "# Backdoor adjustment"
    ]
   },
   {

--- a/docs/source/cevae.ipynb
+++ b/docs/source/cevae.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Causal Effect Variational Autoencoder Example"
+    "# Causal effect variational autoencoder"
    ]
   },
   {

--- a/docs/source/deepscm.ipynb
+++ b/docs/source/deepscm.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Example: Deep structural causal model counterfactuals"
+    "# Deep structural causal model counterfactuals"
    ]
   },
   {

--- a/docs/source/mediation.ipynb
+++ b/docs/source/mediation.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Example: Mediation analysis and (in)direct effects"
+    "# Mediation analysis and (in)direct effects"
    ]
   },
   {

--- a/docs/source/slc.ipynb
+++ b/docs/source/slc.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Example: Structured latent confounders"
+    "# Structured latent confounders"
    ]
   },
   {


### PR DESCRIPTION
addresses #196 

I think that in a future PR we should further refine this header convention. That being said, this tiny PR will help make the existing choices somewhat more consistent.

Freshly built docs look like the following:
<img width="447" alt="Screenshot 2023-09-19 at 1 28 33 PM" src="https://github.com/BasisResearch/chirho/assets/13202375/620fb338-7cb1-4f7a-b7a6-995074e1cc57">
