### PR TITLE
Fix docstring propagation in counterfactual ops

### DIFF
--- a/chirho/counterfactual/ops.py
+++ b/chirho/counterfactual/ops.py
@@ -1,5 +1,6 @@
 from typing import Optional, Tuple, TypeVar
 
+import functools
 import pyro
 
 from chirho.indexed.ops import IndexSet, cond, scatter
@@ -10,7 +11,7 @@ T = TypeVar("T")
 
 
 @pyro.poutine.runtime.effectful(type="split")
-@pyro.poutine.block(hide_types=["intervene"])
+@functools.partial(pyro.poutine.block, hide_types=["intervene"])  # workaround for docstring
 def split(obs: T, acts: Tuple[Intervention[T], ...], **kwargs) -> T:
     """
     Effectful primitive operation for "splitting" a combination of observational and interventional values in a
@@ -40,7 +41,7 @@ def split(obs: T, acts: Tuple[Intervention[T], ...], **kwargs) -> T:
 
 
 @pyro.poutine.runtime.effectful(type="preempt")
-@pyro.poutine.block(hide_types=["intervene"])
+@functools.partial(pyro.poutine.block, hide_types=["intervene"])  # workaround for docstring
 def preempt(
     obs: T, acts: Tuple[Intervention[T], ...], case: Optional[S] = None, **kwargs
 ) -> T:

--- a/chirho/counterfactual/ops.py
+++ b/chirho/counterfactual/ops.py
@@ -1,6 +1,6 @@
+import functools
 from typing import Optional, Tuple, TypeVar
 
-import functools
 import pyro
 
 from chirho.indexed.ops import IndexSet, cond, scatter
@@ -11,7 +11,7 @@ T = TypeVar("T")
 
 
 @pyro.poutine.runtime.effectful(type="split")
-@functools.partial(pyro.poutine.block, hide_types=["intervene"])  # workaround for docstring
+@functools.partial(pyro.poutine.block, hide_types=["intervene"])
 def split(obs: T, acts: Tuple[Intervention[T], ...], **kwargs) -> T:
     """
     Effectful primitive operation for "splitting" a combination of observational and interventional values in a
@@ -41,7 +41,7 @@ def split(obs: T, acts: Tuple[Intervention[T], ...], **kwargs) -> T:
 
 
 @pyro.poutine.runtime.effectful(type="preempt")
-@functools.partial(pyro.poutine.block, hide_types=["intervene"])  # workaround for docstring
+@functools.partial(pyro.poutine.block, hide_types=["intervene"])
 def preempt(
     obs: T, acts: Tuple[Intervention[T], ...], case: Optional[S] = None, **kwargs
 ) -> T:


### PR DESCRIPTION
Resolves #272 

For whatever reason, calling `block` through `functools.partial` causes the docstrings of `split` and `preempt` to be passed through `block` correctly. Renders correctly on my machine.