### PR TITLE
Add missing odeint_kwargs from `torchdiffeq_get_next_interruptions_dynamic`

### DIFF
--- a/chirho/dynamical/internals/ODE/backends/torchdiffeq.py
+++ b/chirho/dynamical/internals/ODE/backends/torchdiffeq.py
@@ -150,6 +150,7 @@ def torchdiffeq_get_next_interruptions_dynamic(
         tuple(getattr(start_state, v) for v in start_state.var_order),
         start_time,
         event_fn=combined_event_f,
+        **solver.odeint_kwargs,
     )
 
     # event_state has both the first and final state of the interrupted simulation. We just want the last.


### PR DESCRIPTION
This tiny PR passes the solver `kwargs` to the `torchdiffeq` dispatch on `get_next_interruptions_dynamic`. These include the solver method, and method-specific options such as step size, etc. all contained with the `TorchDiffEq` solver class.