### PR TITLE
Migrate torchdiffeq dependency from "extras" to "install_requires"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[test]
+          pip install .[test, dynamical]
 
       - name: Lint
         run: ./scripts/lint.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[test, dynamical]
+          pip install .[test,dynamical]
 
       - name: Lint
         run: ./scripts/lint.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master, staging-dynamic ]
   pull_request:
-    branches: [ master, staging-dynamic]
+    branches: [ master, staging-dynamic ]
 
 jobs:
   build:
@@ -46,7 +46,7 @@ jobs:
         run: |
           sudo apt install -y pandoc
           python -m pip install --upgrade pip
-          pip install .[test]
+          pip install .[test, dynamical]
 
       - name: Test
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           sudo apt install -y pandoc
           python -m pip install --upgrade pip
-          pip install .[test, dynamical]
+          pip install .[test,dynamical]
 
       - name: Test
         shell: bash

--- a/chirho/dynamical/internals/ODE/backends/torchdiffeq.py
+++ b/chirho/dynamical/internals/ODE/backends/torchdiffeq.py
@@ -150,6 +150,7 @@ def torchdiffeq_get_next_interruptions_dynamic(
         tuple(getattr(start_state, v) for v in start_state.var_order),
         start_time,
         event_fn=combined_event_f,
+        **solver.odeint_kwargs,
     )
 
     # event_state has both the first and final state of the interrupted simulation. We just want the last.

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -6,3 +6,4 @@ sphinxcontrib-bibtex
 sphinx_rtd_theme==1.3.0
 myst_parser
 nbsphinx
+torchdiffeq

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ EXTRAS_REQUIRE = [
     "tensorboard",
 ]
 
+DYNAMICAL_REQUIRE = ["torchdiffeq"]
+
 setup(
     name="chirho",
     version=VERSION,
@@ -39,9 +41,9 @@ setup(
         # if you add any additional libraries, please also
         # add them to `docs/source/requirements.txt`
         "pyro-ppl>=1.8.5",
-        "torchdiffeq"
     ],
     extras_require={
+        "dynamical": DYNAMICAL_REQUIRE,
         "extras": EXTRAS_REQUIRE,
         "test": EXTRAS_REQUIRE
         + [

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ EXTRAS_REQUIRE = [
     "pytorch-lightning",
     "scikit-image",
     "tensorboard",
-    "torchdiffeq",
 ]
 
 setup(
@@ -38,8 +37,9 @@ setup(
     },
     install_requires=[
         # if you add any additional libraries, please also
-        # add them to `docs/requirements.txt`
+        # add them to `docs/source/requirements.txt`
         "pyro-ppl>=1.8.5",
+        "torchdiffeq"
     ],
     extras_require={
         "extras": EXTRAS_REQUIRE,


### PR DESCRIPTION
Currently, the `dynamics` module requires `torchdiffeq` as its only available backend. While it is unfortunate to add `torchdiffeq` as a core dependency for all of `chirho`, it seems necessary until #202 is addressed.

As the title states, this small PR migrates `torchdiffeq` dependency from "extras", which may or not be installed when a user installs `chirho`, to "install_requires", which will always be installed.