### PR TITLE
Simplify State and Trajectory types

### DIFF
--- a/chirho/dynamical/internals/indexed.py
+++ b/chirho/dynamical/internals/indexed.py
@@ -1,5 +1,7 @@
 from typing import TypeVar
 
+import torch
+
 from chirho.dynamical.ops.dynamical import State, Trajectory
 from chirho.indexed.ops import IndexSet, gather, indices_of, union
 
@@ -51,3 +53,28 @@ def _gather_trajectory(
             for k in trj.keys
         }
     )
+
+
+def _index_last_dim_with_mask(x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    # Index into the last dimension of x with a boolean mask.
+    # TODO AZ — There must be an easier way to do this?
+    # NOTE AZ — this could be easily modified to support the last n dimensions, adapt if needed.
+
+    if mask.dtype != torch.bool:
+        raise ValueError(
+            f"_index_last_dim_with_mask only supports boolean mask indexing, but got dtype {mask.dtype}."
+        )
+
+    # Require that the mask is 1d and aligns with the last dimension of x.
+    if mask.ndim != 1 or mask.shape[0] != x.shape[-1]:
+        raise ValueError(
+            "_index_last_dim_with_mask only supports 1d boolean mask indexing, and must align with the last "
+            f"dimension of x, but got mask shape {mask.shape} and x shape {x.shape}."
+        )
+
+    return torch.masked_select(
+        x,
+        # Get a shape that will broadcast to the shape of x. This will be [1, ..., len(mask)].
+        mask.reshape((1,) * (x.ndim - 1) + mask.shape)
+        # masked_select flattens tensors, so we need to reshape back to the original shape w/ the mask applied.
+    ).reshape(x.shape[:-1] + (int(mask.sum()),))

--- a/tests/dynamical/test_dynamic_interventions.py
+++ b/tests/dynamical/test_dynamic_interventions.py
@@ -40,7 +40,6 @@ intervene_state2 = State(S=torch.tensor(30.0))
 
 def get_state_reached_event_f(target_state: State[torch.tensor], event_dim: int = 0):
     def event_f(t: torch.tensor, state: State[torch.tensor]):
-        # ret = target_state.subtract_shared_variables(state).l2()
         actual, target = state.R, target_state.R
         cf_indices = IndexSet(
             **{


### PR DESCRIPTION
This refactoring PR simplifies the `State` and `Trajectory` types in `chiro.dynamical` and removes some dead code in those types that was never used.