### PR TITLE
Call DynamicTrace._reset on __enter__

### DIFF
--- a/chirho/dynamical/handlers/trace.py
+++ b/chirho/dynamical/handlers/trace.py
@@ -26,6 +26,10 @@ class DynamicTrace(Generic[T], pyro.poutine.messenger.Messenger):
     def _reset(self):
         self.trace = Trajectory()
 
+    def __enter__(self):
+        self._reset()
+        return super().__enter__()
+
     def _pyro_simulate(self, msg) -> None:
         msg["done"] = True
 


### PR DESCRIPTION
This PR fixes what appears to be a bug in `DynamicTrace` - the trajectory is not reset on each new context entry.