### PR TITLE
Add default behavior for `X.t` with `torchdiffeq` solver.

### DIFF
--- a/chirho/dynamical/internals/solver/torchdiffeq.py
+++ b/chirho/dynamical/internals/solver/torchdiffeq.py
@@ -30,6 +30,10 @@ def _deriv(
     env: State[torch.Tensor] = State()
     for var, value in zip(var_order, state):
         setattr(env, var, value)
+
+    assert "t" not in env.keys, "variable name t is reserved for time"
+    env.t = time
+    
     dynamics.diff(ddt, env)
     return tuple(getattr(ddt, var, torch.tensor(0.0)) for var in var_order)
 

--- a/tests/dynamical/dynamical_fixtures.py
+++ b/tests/dynamical/dynamical_fixtures.py
@@ -22,8 +22,10 @@ class UnifiedFixtureDynamics(Dynamics):
             self.gamma = pyro.param("gamma", torch.tensor(0.7), constraints.positive)
 
     def diff(self, dX: State[torch.Tensor], X: State[torch.Tensor]):
-        dX.S = -self.beta * X.S * X.I
-        dX.I = self.beta * X.S * X.I - self.gamma * X.I  # noqa
+        beta = self.beta * (1.0 + 0.1 * torch.sin(0.1 * X.t))  # beta oscilates slowly in time.
+
+        dX.S = -beta * X.S * X.I
+        dX.I = beta * X.S * X.I - self.gamma * X.I  # noqa
         dX.R = self.gamma * X.I
 
     def _unit_measurement_error(self, name: str, x: torch.tensor):


### PR DESCRIPTION
This small PR allows `Dynamics` `diff` methods to include arbitrary functions of time, denoted using `X.t` in the differential expressions.

The additional implementation in `solver/torchdiffeq.py` is copied exactly from @eb8680 's example integration with MIRA in  https://github.com/BasisResearch/chirho/blob/eb-dynamical-load-mira/chirho/dynamical/mira.py.

In addition to being nice default behavior, pushing handling of time into `ChiRho`'s `dynamical` module makes it easier to implement compiled symbolic rate laws in terms of time in the DARPA ASKEM program.