### PR TITLE
Simplify SimulatorEventLoop logic

### DIFF
--- a/chirho/dynamical/handlers/dynamical.py
+++ b/chirho/dynamical/handlers/dynamical.py
@@ -15,7 +15,6 @@ T = TypeVar("T")
 
 
 class SimulatorEventLoop(Generic[T], pyro.poutine.messenger.Messenger):
-
     def _pyro_simulate(self, msg) -> None:
         dynamics, state, start_time, end_time = msg["args"]
         if "solver" in msg["kwargs"]:
@@ -26,7 +25,6 @@ class SimulatorEventLoop(Generic[T], pyro.poutine.messenger.Messenger):
         # Simulate through the timespan, stopping at each interruption. This gives e.g. intervention handlers
         #  a chance to modify the state and/or dynamics before the next span is simulated.
         while start_time < end_time:
-
             with pyro.poutine.messenger.block_messengers(
                 lambda m: m is self or (isinstance(m, Interruption) and m.used)
             ):
@@ -41,7 +39,8 @@ class SimulatorEventLoop(Generic[T], pyro.poutine.messenger.Messenger):
                     h.used = True
 
             with pyro.poutine.messenger.block_messengers(
-                lambda m: isinstance(m, Interruption) and m not in terminal_interruptions
+                lambda m: isinstance(m, Interruption)
+                and m not in terminal_interruptions
             ):
                 dynamics, state = apply_interruptions(dynamics, state)
 

--- a/chirho/dynamical/handlers/dynamical.py
+++ b/chirho/dynamical/handlers/dynamical.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-import warnings
-from typing import Dict, Generic, Tuple, TypeVar
+from typing import Generic, TypeVar
 
 import pyro
 
-from chirho.dynamical.handlers.interruption.interruption import (
-    DynamicInterruption,
-    Interruption,
-)
+from chirho.dynamical.handlers.interruption.interruption import Interruption
 from chirho.dynamical.internals.interruption import (
     apply_interruptions,
     simulate_to_interruption,
@@ -19,78 +15,37 @@ T = TypeVar("T")
 
 
 class SimulatorEventLoop(Generic[T], pyro.poutine.messenger.Messenger):
-    # noinspection PyMethodMayBeStatic
+
     def _pyro_simulate(self, msg) -> None:
-        dynamics, initial_state, start_time, end_time = msg["args"]
+        dynamics, state, start_time, end_time = msg["args"]
         if "solver" in msg["kwargs"]:
             solver = msg["kwargs"]["solver"]
-        else:
-            # Early return to trigger `simulate` ValueError for not having a solver.
+        else:  # Early return to trigger `simulate` ValueError for not having a solver.
             return
-
-        # Initial values. These will be updated in the loop below.
-        span_start_state = initial_state
-        span_start_time = start_time
-
-        previous_terminal_interruptions: Tuple[Interruption, ...] = tuple()
-        interruption_counts: Dict[Interruption, int] = dict()
 
         # Simulate through the timespan, stopping at each interruption. This gives e.g. intervention handlers
         #  a chance to modify the state and/or dynamics before the next span is simulated.
-        while span_start_time < end_time:
-            # Block any interruption's application that wouldn't be the result of an interruption that ended the last
-            #  simulation.
-            with pyro.poutine.messenger.block_messengers(
-                lambda m: isinstance(m, Interruption)
-                and m not in previous_terminal_interruptions
-            ):
-                dynamics, span_start_state = apply_interruptions(
-                    dynamics, span_start_state
-                )
+        while start_time < end_time:
 
-            # Block dynamic interventions that have triggered and applied more than the specified number of times.
-            # This will prevent them from percolating up to the simulate_to_interruption execution.
             with pyro.poutine.messenger.block_messengers(
-                lambda m: (
-                    isinstance(m, DynamicInterruption)
-                    and m.max_applications <= interruption_counts.get(m, 0)
-                )
-                or isinstance(m, SimulatorEventLoop)
+                lambda m: m is self or (isinstance(m, Interruption) and m.used)
             ):
-                (
-                    end_state,
-                    terminal_interruptions,
-                    interruption_time,
-                ) = simulate_to_interruption(  # This call gets handled by interruption handlers.
+                state, terminal_interruptions, start_time = simulate_to_interruption(
                     solver,
                     dynamics,
-                    span_start_state,
-                    span_start_time,
+                    state,
+                    start_time,
                     end_time,
                 )
+                for h in terminal_interruptions:
+                    h.used = True
 
-            if len(terminal_interruptions) > 1:
-                warnings.warn(
-                    "Multiple events fired simultaneously. This results in undefined behavior.",
-                    UserWarning,
-                )
+            with pyro.poutine.messenger.block_messengers(
+                lambda m: isinstance(m, Interruption) and m not in terminal_interruptions
+            ):
+                dynamics, state = apply_interruptions(dynamics, state)
 
-            for interruption in terminal_interruptions:
-                interruption_counts[interruption] = (
-                    interruption_counts.get(interruption, 0) + 1
-                )
-
-            # Set the span_start_time for the next iteration to be the interruption time from the previous.
-            # TODO AZ — we should be able to detect when this eps is too small, as it will repeatedly trigger
-            #  the same event at the same time.
-            span_start_time = interruption_time
-
-            # Update the starting state.
-            span_start_state = end_state
-
-            # Use these to block interruption handlers that weren't responsible for the last interruption.
-            previous_terminal_interruptions = terminal_interruptions
-
-        msg["value"] = end_state
+        msg["value"] = state
         msg["stop"] = True
+        msg["done"] = True
         msg["in_SEL"] = True

--- a/chirho/dynamical/handlers/interruption/array_observation.py
+++ b/chirho/dynamical/handlers/interruption/array_observation.py
@@ -2,12 +2,11 @@ from typing import Dict
 
 import torch
 
-from chirho.dynamical.handlers.interruption.interruption import _PointObservationMixin
 from chirho.dynamical.handlers.trace import DynamicTrace
 from chirho.observational.handlers import condition
 
 
-class NonInterruptingPointObservationArray(DynamicTrace, _PointObservationMixin):
+class NonInterruptingPointObservationArray(DynamicTrace):
     def __init__(
         self,
         times: torch.Tensor,

--- a/chirho/dynamical/handlers/interruption/interruption.py
+++ b/chirho/dynamical/handlers/interruption/interruption.py
@@ -109,19 +109,6 @@ class _PointObservationMixin(Generic[T]):
         msg["name"] = msg["name"] + "_" + str(self.time)
 
 
-class StaticIntervention(Generic[T], StaticInterruption, _InterventionMixin[T]):
-    """
-    This effect handler interrupts a simulation at a given time, and
-    applies an intervention to the state at that time.
-
-    :param time: The time at which the intervention is applied.
-    :param intervention: The instantaneous intervention applied to the state when the event is triggered.
-    """
-    def __init__(self, time: R, intervention: Intervention[State[T]], **kwargs):
-        self.intervention = intervention
-        super().__init__(time, **kwargs)
-
-
 class StaticObservation(Generic[T], StaticInterruption, _PointObservationMixin[T]):
     def __init__(
         self,
@@ -133,6 +120,19 @@ class StaticObservation(Generic[T], StaticInterruption, _PointObservationMixin[T
         # Add a small amount of time to the observation time to ensure that
         # the observation occurs after the logging period.
         super().__init__(time + eps)
+
+
+class StaticIntervention(Generic[T], StaticInterruption, _InterventionMixin[T]):
+    """
+    This effect handler interrupts a simulation at a given time, and
+    applies an intervention to the state at that time.
+
+    :param time: The time at which the intervention is applied.
+    :param intervention: The instantaneous intervention applied to the state when the event is triggered.
+    """
+    def __init__(self, time: R, intervention: Intervention[State[T]], **kwargs):
+        self.intervention = intervention
+        super().__init__(time, **kwargs)
 
 
 class DynamicIntervention(Generic[T], DynamicInterruption, _InterventionMixin[T]):

--- a/chirho/dynamical/handlers/interruption/interruption.py
+++ b/chirho/dynamical/handlers/interruption/interruption.py
@@ -1,6 +1,6 @@
 import numbers
 import warnings
-from typing import Callable, Dict, Generic, Tuple, TypeVar, Union
+from typing import Callable, Dict, Generic, Optional, Tuple, TypeVar, Union
 
 import pyro
 import torch
@@ -39,25 +39,20 @@ class StaticInterruption(Interruption):
     def _pyro_simulate_to_interruption(self, msg) -> None:
         _, _, _, start_time, end_time = msg["args"]
 
-        if "next_static_interruption" in msg["kwargs"]:
-            next_static_interruption = msg["kwargs"]["next_static_interruption"]
-        else:
-            next_static_interruption = None
-
-        # If this interruption occurs within the timespan...
-        if start_time < self.time < end_time:
-            # Usurp the next static interruption if this one occurs earlier.
-            if (
-                next_static_interruption is None
-                or self.time < next_static_interruption.time
-            ):
-                msg["kwargs"]["next_static_interruption"] = self
-        elif self.time >= end_time:
+        if self.time >= end_time:
             warnings.warn(
                 f"{StaticInterruption.__name__} time {self.time} occurred after the end of the timespan "
                 f"{end_time}. This interruption will have no effect.",
                 UserWarning,
             )
+
+        next_static_interrupt: Optional[StaticInterruption] = msg["kwargs"].get(
+            "next_static_interruption", None
+        )
+
+        # Usurp the next static interruption if this one occurs earlier.
+        if next_static_interrupt is None or self.time < next_static_interrupt.time:
+            msg["kwargs"]["next_static_interruption"] = self
 
 
 class DynamicInterruption(Generic[T], Interruption):
@@ -105,7 +100,7 @@ class _PointObservationMixin(Generic[T]):
 
     def _pyro_sample(self, msg):
         # modify observed site names to handle multiple time points
-        msg["name"] = msg["name"] + "_" + str(self.time)
+        msg["name"] = msg["name"] + "_" + str(torch.as_tensor(self.time).item())
 
 
 class StaticObservation(Generic[T], StaticInterruption, _PointObservationMixin[T]):

--- a/chirho/dynamical/handlers/interruption/interruption.py
+++ b/chirho/dynamical/handlers/interruption/interruption.py
@@ -1,29 +1,40 @@
+import numbers
 import warnings
 from typing import Callable, Dict, Generic, Optional, Tuple, TypeVar, Union
 
 import pyro
 import torch
 
-from chirho.dynamical.internals.interventional import intervene
+from chirho.interventional.ops import Intervention, intervene
 from chirho.dynamical.ops.dynamical import State
 from chirho.observational.handlers import condition
 
+import chirho.dynamical.internals.interventional  # noqa: F401
+
+R = Union[numbers.Real, torch.Tensor]
 S = TypeVar("S")
 T = TypeVar("T")
 
 
 class Interruption(pyro.poutine.messenger.Messenger):
+    used: bool
+    
+    def __enter__(self):
+        self.used = False
+        return super().__enter__()
+
     # This is required so that the multiple inheritance works properly and super calls to this method execute the
     #  next implementation in the method resolution order.
     def _pyro_simulate_to_interruption(self, msg) -> None:
         pass
 
 
-# TODO AZ - rename to static interruption?
 class StaticInterruption(Interruption):
-    def __init__(self, time: Union[float, torch.Tensor, T], **kwargs):
+    time: R
+
+    def __init__(self, time: R, **kwargs):
         self.time = torch.as_tensor(time)
-        super().__init__(**kwargs)
+        super().__init__()
 
     def _pyro_simulate_to_interruption(self, msg) -> None:
         _, _, _, start_time, end_time = msg["args"]
@@ -47,47 +58,74 @@ class StaticInterruption(Interruption):
                 f"{end_time}. This interruption will have no effect.",
                 UserWarning,
             )
-        # Note AZiusld10 — This case is actually okay here within simulate_to_interruption, as calls may be specified
-        # for the latter half of a particular timespan, and start only after some previous interruptions. So,
-        # we put it in the simulate preprocess call instead, to get the full timespan. elif self.time < start_time:
-
-        super()._pyro_simulate_to_interruption(msg)
 
 
-class _InterventionMixin(Interruption):
+class DynamicInterruption(Generic[T], Interruption):
+    """
+    :param event_f: An event trigger function that approaches and returns 0.0 when the event should be triggered.
+        This can be designed to trigger when the current state is "close enough" to some trigger state, or when an
+        element of the state exceeds some threshold, etc. It takes both the current time and current state.
+    :param var_order: The full State.var_order. This could be intervention.var_order if the intervention applies
+        to the full state.
+    """
+    def __init__(
+        self,
+        event_f: Callable[[R, State[T]], R],
+        var_order: Tuple[str, ...],
+        **kwargs
+    ):
+        self.event_f = event_f
+        self.var_order = var_order
+        super().__init__()
+
+    def _pyro_simulate_to_interruption(self, msg) -> None:
+        msg["kwargs"].setdefault("dynamic_interruptions", []).append(self)
+
+
+class _InterventionMixin(Generic[T]):
     """
     We use this to provide the same functionality to both StaticIntervention and the DynamicIntervention,
      while allowing DynamicIntervention to not inherit StaticInterruption functionality.
     """
-
-    def __init__(self, intervention: State[T], **kwargs):
-        super().__init__(**kwargs)
-        self.intervention = intervention
+    intervention: Intervention[State[T]]
 
     def _pyro_apply_interruptions(self, msg) -> None:
         dynamics, initial_state = msg["args"]
         msg["args"] = (dynamics, intervene(initial_state, self.intervention))
 
 
-class StaticIntervention(StaticInterruption, _InterventionMixin):
+class _PointObservationMixin(Generic[T]):
+    data: Dict[str, T]
+    time: R
+
+    def _pyro_apply_interruptions(self, msg) -> None:
+        dynamics, current_state = msg["args"]
+
+        with condition(data=self.data):
+            dynamics.observation(current_state)
+
+    def _pyro_sample(self, msg):
+        # modify observed site names to handle multiple time points
+        msg["name"] = msg["name"] + "_" + str(self.time)
+
+
+class StaticIntervention(Generic[T], StaticInterruption, _InterventionMixin[T]):
     """
     This effect handler interrupts a simulation at a given time, and
     applies an intervention to the state at that time.
+
+    :param time: The time at which the intervention is applied.
+    :param intervention: The instantaneous intervention applied to the state when the event is triggered.
     """
-
-    pass
-
-
-# Just a type rn for type checking. This should eventually have shared code in it useful for different types of point
-#  observations.
-class _PointObservationMixin:
-    pass
+    def __init__(self, time: R, intervention: Intervention[State[T]], **kwargs):
+        self.intervention = intervention
+        super().__init__(time, **kwargs)
 
 
-class StaticObservation(StaticInterruption, _PointObservationMixin):
+class StaticObservation(Generic[T], StaticInterruption, _PointObservationMixin[T]):
     def __init__(
         self,
-        time: float,
+        time: R,
         data: Dict[str, T],
         eps: float = 1e-6,
     ):
@@ -96,84 +134,21 @@ class StaticObservation(StaticInterruption, _PointObservationMixin):
         # the observation occurs after the logging period.
         super().__init__(time + eps)
 
-    def _pyro_apply_interruptions(self, msg) -> None:
-        dynamics, current_state = msg["args"]
 
-        with condition(data=self.data):
-            with pyro.poutine.messenger.block_messengers(
-                lambda m: isinstance(m, _PointObservationMixin) and (m is not self)
-            ):
-                dynamics.observation(current_state)
-
-    def _pyro_sample(self, msg):
-        # modify observed site names to handle multiple time points
-        msg["name"] = msg["name"] + "_" + str(self.time.item())
-
-
-class DynamicInterruption(Generic[T], Interruption):
-    def __init__(
-        self,
-        event_f: Callable[[T, State[T]], T],
-        var_order: Tuple[str, ...],
-        max_applications: Optional[int] = None,
-        **kwargs,
-    ):
-        """
-        :param event_f: An event trigger function that approaches and returns 0.0 when the event should be triggered.
-         This can be designed to trigger when the current state is "close enough" to some trigger state, or when an
-         element of the state exceeds some threshold, etc. It takes both the current time and current state.
-        :param var_order: The full State.var_order. This could be intervention.var_order if the intervention applies
-         to the full state.
-        :param max_applications: The maximum number of times this dynamic interruption can be applied. If None, there
-            is no limit.
-        """
-
-        super().__init__(**kwargs)
-        self.event_f = event_f
-        self.var_order = var_order
-
-        if max_applications is None or max_applications > 1:
-            # This implies an infinite number of applications, but we don't support that yet, as we need some way
-            #  of disabling a dynamic event proc for some time epsilon after it is triggered each time, otherwise
-            #  it will just repeatedly trigger and the sim won't advance.
-            raise NotImplementedError(
-                "More than one application is not yet implemented."
-            )
-
-        self.max_applications = max_applications
-
-    def _pyro_simulate_to_interruption(self, msg) -> None:
-        if "dynamic_interruptions" not in msg["kwargs"]:
-            msg["kwargs"]["dynamic_interruptions"] = []
-
-        # Add self to the collection of dynamic interruptions.
-        # TODO: This doesn't appear to be used anywhere. Is it needed?
-        if self not in msg.get("ignored_dynamic_interruptions", []):
-            msg["kwargs"]["dynamic_interruptions"].append(self)
-
-        super()._pyro_simulate_to_interruption(msg)
-
-
-class DynamicIntervention(DynamicInterruption, _InterventionMixin):
+class DynamicIntervention(Generic[T], DynamicInterruption, _InterventionMixin[T]):
     """
     This effect handler interrupts a simulation when the given dynamic event function returns 0.0, and
     applies an intervention to the state at that time.
+
+    :param intervention: The instantaneous intervention applied to the state when the event is triggered.
     """
 
-    def __int__(
+    def __init__(
         self,
-        intervention: State[T],
-        event_f: Callable[[T, State[T]], T],
+        event_f: Callable[[R, State[T]], R],
         var_order: Tuple[str, ...],
-        max_applications: Optional[int] = None,
+        intervention: Intervention[State[T]],
+        **kwargs,
     ):
-        """
-        :param intervention: The instantaneous intervention applied to the state when the event is triggered.
-        """
-
-        super().__init__(
-            event_f=event_f,
-            var_order=var_order,
-            max_applications=max_applications,
-            intervention=intervention,
-        )
+        self.intervention = intervention
+        super().__init__(event_f, var_order, **kwargs)

--- a/chirho/dynamical/handlers/interruption/interruption.py
+++ b/chirho/dynamical/handlers/interruption/interruption.py
@@ -23,17 +23,15 @@ class Interruption(pyro.poutine.messenger.Messenger):
         self.used = False
         return super().__enter__()
 
-    # This is required so that the multiple inheritance works properly and super calls to this method execute the
-    #  next implementation in the method resolution order.
     def _pyro_simulate_to_interruption(self, msg) -> None:
-        pass
+        raise NotImplementedError("shouldn't be here!")
 
 
 class StaticInterruption(Interruption):
     time: R
 
     def __init__(self, time: R, **kwargs):
-        self.time = torch.as_tensor(time)
+        self.time = torch.as_tensor(time)  # TODO enforce this where it is needed
         super().__init__()
 
     def _pyro_simulate_to_interruption(self, msg) -> None:

--- a/chirho/dynamical/internals/interruption.py
+++ b/chirho/dynamical/internals/interruption.py
@@ -125,31 +125,3 @@ def apply_interruptions(
     """
     # Default is to do nothing.
     return dynamics, start_state
-
-
-class ShallowHandler(pyro.poutine.messenger.Messenger):
-    _used: bool
-
-    def __enter__(self):
-        self._used = False
-        return super().__enter__()
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if self._used:
-            assert self not in pyro.poutine.runtime._PYRO_STACK
-        else:
-            return super().__exit__(exc_type, exc_val, exc_tb)
-
-    def _uninstall(self):
-        index = pyro.poutine.runtime._PYRO_STACK.index(self)
-        pyro.poutine.runtime._PYRO_STACK.pop(index)
-
-    def _process_message(self, msg):
-        if hasattr(self, f"_pyro_{msg['type']}") or hasattr(self, f"_pyro_post_{msg['type']}"):
-            self._used = True
-            return super()._process_message(msg)
-
-    def _postprocess_message(self, msg):
-        super()._postprocess_message(msg)
-        if self._used:
-            msg["continuation"] = lambda _: self._uninstall()

--- a/chirho/dynamical/internals/interruption.py
+++ b/chirho/dynamical/internals/interruption.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import functools
-from typing import TYPE_CHECKING, List, Optional, Tuple, TypeVar
+import numbers
+from typing import TYPE_CHECKING, List, Optional, Tuple, TypeVar, Union
 
 import pyro
+import torch
 
 from chirho.dynamical.handlers.interruption.interruption import (
     DynamicInterruption,
@@ -16,6 +18,7 @@ if TYPE_CHECKING:
     from chirho.dynamical.handlers.solver import Solver
 
 
+R = Union[numbers.Real, torch.Tensor]
 S = TypeVar("S")
 T = TypeVar("T")
 
@@ -26,13 +29,13 @@ def simulate_to_interruption(
     solver: "Solver",  # Quoted type necessary w/ TYPE_CHECKING to avoid circular import error
     dynamics: Dynamics[S, T],
     start_state: State[T],
-    start_time: T,
-    end_time: T,
+    start_time: R,
+    end_time: R,
     *,
     next_static_interruption: Optional[StaticInterruption] = None,
     dynamic_interruptions: List[DynamicInterruption] = [],
     **kwargs,
-) -> Tuple[State[T], Tuple[Interruption, ...], T]:
+) -> Tuple[State[T], Tuple[Interruption, ...], R]:
     """
     Simulate a dynamical system until the next interruption. This will be either one of the passed
     dynamic interruptions, the next static interruption, or the end time, whichever comes first.
@@ -64,13 +67,13 @@ def get_next_interruptions(
     solver: "Solver",  # Quoted type necessary w/ TYPE_CHECKING to avoid circular import error
     dynamics: Dynamics[S, T],
     start_state: State[T],
-    start_time: T,
-    end_time: T,
+    start_time: R,
+    end_time: R,
     *,
     next_static_interruption: Optional[StaticInterruption] = None,
     dynamic_interruptions: List[DynamicInterruption] = [],
     **kwargs,
-) -> Tuple[Tuple[Interruption, ...], T]:
+) -> Tuple[Tuple[Interruption, ...], R]:
     nodyn = len(dynamic_interruptions) == 0
     nostat = next_static_interruption is None
 
@@ -107,10 +110,10 @@ def get_next_interruptions_dynamic(
     solver: "Solver",  # Quoted type necessary w/ TYPE_CHECKING to avoid circular import error
     dynamics: Dynamics[S, T],
     start_state: State[T],
-    start_time: T,
+    start_time: R,
     next_static_interruption: StaticInterruption,
     dynamic_interruptions: List[DynamicInterruption],
-) -> Tuple[Tuple[Interruption, ...], T]:
+) -> Tuple[Tuple[Interruption, ...], R]:
     raise NotImplementedError(
         f"get_next_interruptions_dynamic not implemented for type {type(dynamics)}"
     )

--- a/tests/dynamical/test_static_observation.py
+++ b/tests/dynamical/test_static_observation.py
@@ -87,9 +87,7 @@ def _get_compatible_observations(obs_handler, time, data):
 
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
 @pytest.mark.parametrize(
-    # "obs_handler", [StaticObservation, NonInterruptingPointObservationArray]
-    "obs_handler",
-    [NonInterruptingPointObservationArray],
+    "obs_handler", [StaticObservation, NonInterruptingPointObservationArray]
 )
 def test_log_prob_exists(model, obs_handler):
     """


### PR DESCRIPTION
This refactoring PR simplifies the core `SimulatorEventLoop` and `Interruption` logic. It also fixes some type errors.