### PR TITLE
Rename Dynamics to InPlaceDynamics

### DIFF
--- a/chirho/dynamical/handlers/interruption/array_observation.py
+++ b/chirho/dynamical/handlers/interruption/array_observation.py
@@ -31,7 +31,7 @@ class NonInterruptingPointObservationArray(DynamicTrace, _PointObservationMixin)
         super().__init__(times)
 
     def _pyro_post_simulate(self, msg) -> None:
-        dynamics: ObservableInPlaceDynamics[torch.Tensor, torch.Tensor] = msg["args"][0]
+        dynamics: ObservableInPlaceDynamics[torch.Tensor] = msg["args"][0]
 
         if "in_SEL" not in msg.keys():
             msg["in_SEL"] = False

--- a/chirho/dynamical/handlers/interruption/array_observation.py
+++ b/chirho/dynamical/handlers/interruption/array_observation.py
@@ -4,6 +4,7 @@ import torch
 
 from chirho.dynamical.handlers.interruption.interruption import _PointObservationMixin
 from chirho.dynamical.handlers.trace import DynamicTrace
+from chirho.dynamical.ops.dynamical import ObservableInPlaceDynamics
 from chirho.observational.handlers import condition
 
 
@@ -30,7 +31,7 @@ class NonInterruptingPointObservationArray(DynamicTrace, _PointObservationMixin)
         super().__init__(times)
 
     def _pyro_post_simulate(self, msg) -> None:
-        dynamics, _, _, _ = msg["args"]
+        dynamics: ObservableInPlaceDynamics[torch.Tensor, torch.Tensor] = msg["args"][0]
 
         if "in_SEL" not in msg.keys():
             msg["in_SEL"] = False

--- a/chirho/dynamical/handlers/interruption/interruption.py
+++ b/chirho/dynamical/handlers/interruption/interruption.py
@@ -97,7 +97,7 @@ class StaticObservation(Generic[T], StaticInterruption, _PointObservationMixin):
         super().__init__(time + eps)
 
     def _pyro_apply_interruptions(self, msg) -> None:
-        dynamics: ObservableInPlaceDynamics[T, None] = msg["args"][0]
+        dynamics: ObservableInPlaceDynamics[T] = msg["args"][0]
         current_state: State[T] = msg["args"][1]
 
         with condition(data=self.data):

--- a/chirho/dynamical/internals/dynamical.py
+++ b/chirho/dynamical/internals/dynamical.py
@@ -16,7 +16,7 @@ T = TypeVar("T")
 @functools.singledispatch
 def simulate_trajectory(
     solver: "Solver",  # Quoted type necessary w/ TYPE_CHECKING to avoid circular import error
-    dynamics: InPlaceDynamics[S, T],
+    dynamics: InPlaceDynamics[T],
     initial_state: State[T],
     timespan: T,
     **kwargs,

--- a/chirho/dynamical/internals/dynamical.py
+++ b/chirho/dynamical/internals/dynamical.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 from typing import TYPE_CHECKING, TypeVar
 
-from chirho.dynamical.ops.dynamical import Dynamics, State, Trajectory
+from chirho.dynamical.ops.dynamical import InPlaceDynamics, State, Trajectory
 
 if TYPE_CHECKING:
     from chirho.dynamical.handlers.solver import Solver
@@ -16,7 +16,7 @@ T = TypeVar("T")
 @functools.singledispatch
 def simulate_trajectory(
     solver: "Solver",  # Quoted type necessary w/ TYPE_CHECKING to avoid circular import error
-    dynamics: Dynamics[S, T],
+    dynamics: InPlaceDynamics[S, T],
     initial_state: State[T],
     timespan: T,
     **kwargs,

--- a/chirho/dynamical/internals/interruption.py
+++ b/chirho/dynamical/internals/interruption.py
@@ -24,7 +24,7 @@ T = TypeVar("T")
 @pyro.poutine.runtime.effectful(type="simulate_to_interruption")
 def simulate_to_interruption(
     solver: "Solver",  # Quoted type necessary w/ TYPE_CHECKING to avoid circular import error
-    dynamics: InPlaceDynamics[S, T],
+    dynamics: InPlaceDynamics[T],
     start_state: State[T],
     start_time: T,
     end_time: T,
@@ -62,7 +62,7 @@ def simulate_to_interruption(
 
 def get_next_interruptions(
     solver: "Solver",  # Quoted type necessary w/ TYPE_CHECKING to avoid circular import error
-    dynamics: InPlaceDynamics[S, T],
+    dynamics: InPlaceDynamics[T],
     start_state: State[T],
     start_time: T,
     end_time: T,
@@ -105,7 +105,7 @@ def get_next_interruptions(
 @functools.singledispatch
 def get_next_interruptions_dynamic(
     solver: "Solver",  # Quoted type necessary w/ TYPE_CHECKING to avoid circular import error
-    dynamics: InPlaceDynamics[S, T],
+    dynamics: InPlaceDynamics[T],
     start_state: State[T],
     start_time: T,
     next_static_interruption: StaticInterruption,
@@ -118,8 +118,8 @@ def get_next_interruptions_dynamic(
 
 @pyro.poutine.runtime.effectful(type="apply_interruptions")
 def apply_interruptions(
-    dynamics: InPlaceDynamics[S, T], start_state: State[T]
-) -> Tuple[InPlaceDynamics[S, T], State[T]]:
+    dynamics: InPlaceDynamics[T], start_state: State[T]
+) -> Tuple[InPlaceDynamics[T], State[T]]:
     """
     Apply the effects of an interruption to a dynamical system.
     """

--- a/chirho/dynamical/internals/interruption.py
+++ b/chirho/dynamical/internals/interruption.py
@@ -10,7 +10,7 @@ from chirho.dynamical.handlers.interruption.interruption import (
     Interruption,
     StaticInterruption,
 )
-from chirho.dynamical.ops.dynamical import Dynamics, State, simulate
+from chirho.dynamical.ops.dynamical import InPlaceDynamics, State, simulate
 
 if TYPE_CHECKING:
     from chirho.dynamical.handlers.solver import Solver
@@ -24,7 +24,7 @@ T = TypeVar("T")
 @pyro.poutine.runtime.effectful(type="simulate_to_interruption")
 def simulate_to_interruption(
     solver: "Solver",  # Quoted type necessary w/ TYPE_CHECKING to avoid circular import error
-    dynamics: Dynamics[S, T],
+    dynamics: InPlaceDynamics[S, T],
     start_state: State[T],
     start_time: T,
     end_time: T,
@@ -62,7 +62,7 @@ def simulate_to_interruption(
 
 def get_next_interruptions(
     solver: "Solver",  # Quoted type necessary w/ TYPE_CHECKING to avoid circular import error
-    dynamics: Dynamics[S, T],
+    dynamics: InPlaceDynamics[S, T],
     start_state: State[T],
     start_time: T,
     end_time: T,
@@ -105,7 +105,7 @@ def get_next_interruptions(
 @functools.singledispatch
 def get_next_interruptions_dynamic(
     solver: "Solver",  # Quoted type necessary w/ TYPE_CHECKING to avoid circular import error
-    dynamics: Dynamics[S, T],
+    dynamics: InPlaceDynamics[S, T],
     start_state: State[T],
     start_time: T,
     next_static_interruption: StaticInterruption,
@@ -118,8 +118,8 @@ def get_next_interruptions_dynamic(
 
 @pyro.poutine.runtime.effectful(type="apply_interruptions")
 def apply_interruptions(
-    dynamics: Dynamics[S, T], start_state: State[T]
-) -> Tuple[Dynamics[S, T], State[T]]:
+    dynamics: InPlaceDynamics[S, T], start_state: State[T]
+) -> Tuple[InPlaceDynamics[S, T], State[T]]:
     """
     Apply the effects of an interruption to a dynamical system.
     """

--- a/chirho/dynamical/internals/solver/torchdiffeq.py
+++ b/chirho/dynamical/internals/solver/torchdiffeq.py
@@ -12,7 +12,7 @@ from chirho.dynamical.internals.interruption import (
     StaticInterruption,
     get_next_interruptions_dynamic,
 )
-from chirho.dynamical.ops import Dynamics
+from chirho.dynamical.ops import InPlaceDynamics
 from chirho.dynamical.ops.dynamical import State, Trajectory, simulate
 
 S = TypeVar("S")
@@ -21,7 +21,7 @@ T = TypeVar("T")
 
 # noinspection PyMethodParameters
 def _deriv(
-    dynamics: Dynamics[torch.Tensor, torch.Tensor],
+    dynamics: InPlaceDynamics[torch.Tensor, torch.Tensor],
     var_order: Tuple[str, ...],
     time: torch.Tensor,
     state: Tuple[torch.Tensor, ...],
@@ -39,7 +39,7 @@ def _deriv(
 
 
 def _torchdiffeq_ode_simulate_inner(
-    dynamics: Dynamics[torch.Tensor, torch.Tensor],
+    dynamics: InPlaceDynamics[torch.Tensor, torch.Tensor],
     initial_state: State[torch.Tensor],
     timespan,
     **odeint_kwargs,
@@ -105,7 +105,7 @@ def _batched_odeint(
 @simulate.register(TorchDiffEq)
 def torchdiffeq_ode_simulate(
     solver: TorchDiffEq,
-    dynamics: Dynamics[torch.Tensor, torch.Tensor],
+    dynamics: InPlaceDynamics[torch.Tensor, torch.Tensor],
     initial_state: State[torch.Tensor],
     start_time: torch.Tensor,
     end_time: torch.Tensor,
@@ -120,7 +120,7 @@ def torchdiffeq_ode_simulate(
 @simulate_trajectory.register(TorchDiffEq)
 def torchdiffeq_ode_simulate_trajectory(
     solver: TorchDiffEq,
-    dynamics: Dynamics[torch.Tensor, torch.Tensor],
+    dynamics: InPlaceDynamics[torch.Tensor, torch.Tensor],
     initial_state: State[torch.Tensor],
     timespan: torch.Tensor,
 ) -> Trajectory[torch.Tensor]:
@@ -132,7 +132,7 @@ def torchdiffeq_ode_simulate_trajectory(
 @get_next_interruptions_dynamic.register(TorchDiffEq)
 def torchdiffeq_get_next_interruptions_dynamic(
     solver: TorchDiffEq,
-    dynamics: Dynamics[torch.Tensor, torch.Tensor],
+    dynamics: InPlaceDynamics[torch.Tensor, torch.Tensor],
     start_state: State[torch.Tensor],
     start_time: torch.Tensor,
     next_static_interruption: StaticInterruption,

--- a/chirho/dynamical/internals/solver/torchdiffeq.py
+++ b/chirho/dynamical/internals/solver/torchdiffeq.py
@@ -21,7 +21,7 @@ T = TypeVar("T")
 
 # noinspection PyMethodParameters
 def _deriv(
-    dynamics: InPlaceDynamics[torch.Tensor, torch.Tensor],
+    dynamics: InPlaceDynamics[torch.Tensor],
     var_order: Tuple[str, ...],
     time: torch.Tensor,
     state: Tuple[torch.Tensor, ...],
@@ -39,7 +39,7 @@ def _deriv(
 
 
 def _torchdiffeq_ode_simulate_inner(
-    dynamics: InPlaceDynamics[torch.Tensor, torch.Tensor],
+    dynamics: InPlaceDynamics[torch.Tensor],
     initial_state: State[torch.Tensor],
     timespan,
     **odeint_kwargs,
@@ -105,7 +105,7 @@ def _batched_odeint(
 @simulate.register(TorchDiffEq)
 def torchdiffeq_ode_simulate(
     solver: TorchDiffEq,
-    dynamics: InPlaceDynamics[torch.Tensor, torch.Tensor],
+    dynamics: InPlaceDynamics[torch.Tensor],
     initial_state: State[torch.Tensor],
     start_time: torch.Tensor,
     end_time: torch.Tensor,
@@ -120,7 +120,7 @@ def torchdiffeq_ode_simulate(
 @simulate_trajectory.register(TorchDiffEq)
 def torchdiffeq_ode_simulate_trajectory(
     solver: TorchDiffEq,
-    dynamics: InPlaceDynamics[torch.Tensor, torch.Tensor],
+    dynamics: InPlaceDynamics[torch.Tensor],
     initial_state: State[torch.Tensor],
     timespan: torch.Tensor,
 ) -> Trajectory[torch.Tensor]:
@@ -132,7 +132,7 @@ def torchdiffeq_ode_simulate_trajectory(
 @get_next_interruptions_dynamic.register(TorchDiffEq)
 def torchdiffeq_get_next_interruptions_dynamic(
     solver: TorchDiffEq,
-    dynamics: InPlaceDynamics[torch.Tensor, torch.Tensor],
+    dynamics: InPlaceDynamics[torch.Tensor],
     start_state: State[torch.Tensor],
     start_time: torch.Tensor,
     next_static_interruption: StaticInterruption,

--- a/chirho/dynamical/ops/__init__.py
+++ b/chirho/dynamical/ops/__init__.py
@@ -1,1 +1,1 @@
-from .dynamical import Dynamics, State, Trajectory, simulate  # noqa: F401
+from .dynamical import InPlaceDynamics, State, Trajectory, simulate  # noqa: F401

--- a/chirho/dynamical/ops/dynamical.py
+++ b/chirho/dynamical/ops/dynamical.py
@@ -2,7 +2,6 @@ import functools
 import numbers
 from typing import (
     TYPE_CHECKING,
-    Callable,
     FrozenSet,
     Generic,
     Optional,
@@ -107,9 +106,6 @@ class Trajectory(Generic[T], State[_Sliceable[T]]):
             **{k: getattr(self, k) for k in self.keys}
         )
         return ret
-
-
-Dynamics = Callable[[State[S]], State[S]]
 
 
 @runtime_checkable

--- a/chirho/dynamical/ops/dynamical.py
+++ b/chirho/dynamical/ops/dynamical.py
@@ -109,10 +109,22 @@ class Trajectory(Generic[T], State[_Sliceable[T]]):
         return ret
 
 
+Dynamics = Callable[[State[S]], State[S]]
+
+
 @runtime_checkable
-class InPlaceDynamics(Protocol[S, T]):
-    diff: Callable[[State[S], State[S]], T]
-    observation: Callable[[State[S]], None]
+class InPlaceDynamics(Protocol[S, T_co]):
+    def diff(self, __state: State[S], __dstate: State[S]) -> T_co:
+        ...
+
+
+@runtime_checkable
+class ObservableInPlaceDynamics(InPlaceDynamics[S, T_co], Protocol[S, T_co]):
+    def diff(self, __state: State[S], __dstate: State[S]) -> T_co:
+        ...
+
+    def observation(self, __state: State[S] | Trajectory[S]) -> None:
+        ...
 
 
 @pyro.poutine.runtime.effectful(type="simulate")

--- a/chirho/dynamical/ops/dynamical.py
+++ b/chirho/dynamical/ops/dynamical.py
@@ -123,7 +123,7 @@ class ObservableInPlaceDynamics(InPlaceDynamics[S], Protocol[S]):
     def diff(self, __state: State[S], __dstate: State[S]) -> None:
         ...
 
-    def observation(self, __state: State[S] | Trajectory[S]) -> None:
+    def observation(self, __state: Union[State[S], Trajectory[S]]) -> None:
         ...
 
 

--- a/chirho/dynamical/ops/dynamical.py
+++ b/chirho/dynamical/ops/dynamical.py
@@ -113,14 +113,14 @@ Dynamics = Callable[[State[S]], State[S]]
 
 
 @runtime_checkable
-class InPlaceDynamics(Protocol[S, T_co]):
-    def diff(self, __state: State[S], __dstate: State[S]) -> T_co:
+class InPlaceDynamics(Protocol[S]):
+    def diff(self, __state: State[S], __dstate: State[S]) -> None:
         ...
 
 
 @runtime_checkable
-class ObservableInPlaceDynamics(InPlaceDynamics[S, T_co], Protocol[S, T_co]):
-    def diff(self, __state: State[S], __dstate: State[S]) -> T_co:
+class ObservableInPlaceDynamics(InPlaceDynamics[S], Protocol[S]):
+    def diff(self, __state: State[S], __dstate: State[S]) -> None:
         ...
 
     def observation(self, __state: State[S] | Trajectory[S]) -> None:
@@ -129,7 +129,7 @@ class ObservableInPlaceDynamics(InPlaceDynamics[S, T_co], Protocol[S, T_co]):
 
 @pyro.poutine.runtime.effectful(type="simulate")
 def simulate(
-    dynamics: InPlaceDynamics[S, T],
+    dynamics: InPlaceDynamics[T],
     initial_state: State[T],
     start_time: R,
     end_time: R,
@@ -158,7 +158,7 @@ def simulate(
 @functools.singledispatch
 def _simulate(
     solver: "Solver",  # Quoted type necessary w/ TYPE_CHECKING to avoid circular import error
-    dynamics: InPlaceDynamics[S, T],
+    dynamics: InPlaceDynamics[T],
     initial_state: State[T],
     start_time: R,
     end_time: R,

--- a/tests/dynamical/dynamical_fixtures.py
+++ b/tests/dynamical/dynamical_fixtures.py
@@ -4,12 +4,12 @@ import pyro
 import torch
 from pyro.distributions import Normal, Uniform, constraints
 
-from chirho.dynamical.ops.dynamical import Dynamics, State, Trajectory
+from chirho.dynamical.ops.dynamical import InPlaceDynamics, State, Trajectory
 
 T = TypeVar("T")
 
 
-class UnifiedFixtureDynamics(Dynamics):
+class UnifiedFixtureDynamics(InPlaceDynamics):
     def __init__(self, beta=None, gamma=None):
         super().__init__()
 

--- a/tests/dynamical/test_dynamic_interventions.py
+++ b/tests/dynamical/test_dynamic_interventions.py
@@ -14,7 +14,7 @@ from chirho.dynamical.handlers import (
     SimulatorEventLoop,
 )
 from chirho.dynamical.handlers.solver import TorchDiffEq
-from chirho.dynamical.ops import Dynamics, State, simulate
+from chirho.dynamical.ops import InPlaceDynamics, State, simulate
 from chirho.indexed.ops import IndexSet, gather, indices_of, union
 
 from .dynamical_fixtures import UnifiedFixtureDynamics
@@ -390,7 +390,7 @@ def test_split_twinworld_dynamic_matches_output(
 
 
 def test_grad_of_dynamic_intervention_event_f_params():
-    class Model(Dynamics):
+    class Model(InPlaceDynamics):
         def diff(self, dX: State[torch.Tensor], X: State[torch.Tensor]):
             dX.x = tt(1.0)
             dX.z = X.dz


### PR DESCRIPTION
As part of changing the interface to `simulate` to be functional, this refactoring PR renames the abstract interface type `Dynamics` to `InPlaceDynamics` and separates out the `observation` method into a subtype. It also removes a type variable in the `Dynamics` type which was not being used.