### PR TITLE
Rename NonInterruptingPointObservationArray to StaticBatchObservation

### DIFF
--- a/chirho/dynamical/handlers/__init__.py
+++ b/chirho/dynamical/handlers/__init__.py
@@ -1,6 +1,6 @@
 from .dynamical import SimulatorEventLoop  # noqa: F401
 from .interruption.array_observation import (  # noqa: F401
-    NonInterruptingPointObservationArray,
+    StaticBatchObservation,
 )
 from .interruption.interruption import (  # noqa: F401
     DynamicInterruption,

--- a/chirho/dynamical/handlers/__init__.py
+++ b/chirho/dynamical/handlers/__init__.py
@@ -1,7 +1,5 @@
 from .dynamical import SimulatorEventLoop  # noqa: F401
-from .interruption.array_observation import (  # noqa: F401
-    StaticBatchObservation,
-)
+from .interruption.array_observation import StaticBatchObservation  # noqa: F401
 from .interruption.interruption import (  # noqa: F401
     DynamicInterruption,
     DynamicIntervention,

--- a/chirho/dynamical/handlers/interruption/array_observation.py
+++ b/chirho/dynamical/handlers/interruption/array_observation.py
@@ -7,7 +7,7 @@ from chirho.dynamical.handlers.trace import DynamicTrace
 from chirho.observational.handlers import condition
 
 
-class NonInterruptingPointObservationArray(DynamicTrace, _PointObservationMixin):
+class StaticBatchObservation(DynamicTrace, _PointObservationMixin):
     def __init__(
         self,
         times: torch.Tensor,

--- a/tests/dynamical/obs_runtime.py
+++ b/tests/dynamical/obs_runtime.py
@@ -9,8 +9,8 @@ from pyro.distributions import Normal, Uniform
 
 from chirho.dynamical.handlers import (
     DynamicIntervention,
-    StaticBatchObservation,
     SimulatorEventLoop,
+    StaticBatchObservation,
 )
 from chirho.dynamical.handlers.solver import TorchDiffEq
 from chirho.dynamical.ops import State, simulate

--- a/tests/dynamical/obs_runtime.py
+++ b/tests/dynamical/obs_runtime.py
@@ -9,7 +9,7 @@ from pyro.distributions import Normal, Uniform
 
 from chirho.dynamical.handlers import (
     DynamicIntervention,
-    NonInterruptingPointObservationArray,
+    StaticBatchObservation,
     SimulatorEventLoop,
 )
 from chirho.dynamical.handlers.solver import TorchDiffEq
@@ -57,7 +57,7 @@ def conditioned_sir(
     for obs in data.values():
         obs_time = obs[0].item()
         obs_data = obs[1]
-        managers.append(NonInterruptingPointObservationArray(obs_time, obs_data))
+        managers.append(StaticBatchObservation(obs_time, obs_data))
     if include_dynamic_intervention:
         event_f = make_event_fn(State(I=torch.tensor(30.0)))
         managers.append(

--- a/tests/dynamical/test_handler_composition.py
+++ b/tests/dynamical/test_handler_composition.py
@@ -8,8 +8,8 @@ from pyro.distributions import Normal
 from chirho.counterfactual.handlers import TwinWorldCounterfactual
 from chirho.dynamical.handlers import (
     DynamicTrace,
-    StaticBatchObservation,
     SimulatorEventLoop,
+    StaticBatchObservation,
     StaticIntervention,
 )
 from chirho.dynamical.handlers.solver import TorchDiffEq
@@ -56,9 +56,7 @@ reparam_config = AutoSoftConditioning(scale=0.01, alpha=0.5)
 twin_world = TwinWorldCounterfactual()
 intervention = StaticIntervention(time=superspreader_time, intervention=counterfactual)
 reparam = pyro.poutine.reparam(config=reparam_config)
-vec_obs3 = StaticBatchObservation(
-    times=flight_landing_times, data=flight_landing_data
-)
+vec_obs3 = StaticBatchObservation(times=flight_landing_times, data=flight_landing_data)
 
 
 def counterf_model():

--- a/tests/dynamical/test_handler_composition.py
+++ b/tests/dynamical/test_handler_composition.py
@@ -8,7 +8,7 @@ from pyro.distributions import Normal
 from chirho.counterfactual.handlers import TwinWorldCounterfactual
 from chirho.dynamical.handlers import (
     DynamicTrace,
-    NonInterruptingPointObservationArray,
+    StaticBatchObservation,
     SimulatorEventLoop,
     StaticIntervention,
 )
@@ -56,7 +56,7 @@ reparam_config = AutoSoftConditioning(scale=0.01, alpha=0.5)
 twin_world = TwinWorldCounterfactual()
 intervention = StaticIntervention(time=superspreader_time, intervention=counterfactual)
 reparam = pyro.poutine.reparam(config=reparam_config)
-vec_obs3 = NonInterruptingPointObservationArray(
+vec_obs3 = StaticBatchObservation(
     times=flight_landing_times, data=flight_landing_data
 )
 

--- a/tests/dynamical/test_static_observation.py
+++ b/tests/dynamical/test_static_observation.py
@@ -8,8 +8,8 @@ from pyro.infer.autoguide import AutoMultivariateNormal
 
 from chirho.dynamical.handlers import (
     DynamicTrace,
-    StaticBatchObservation,
     SimulatorEventLoop,
+    StaticBatchObservation,
     StaticObservation,
 )
 from chirho.dynamical.handlers.solver import TorchDiffEq
@@ -86,9 +86,7 @@ def _get_compatible_observations(obs_handler, time, data):
 
 
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
-@pytest.mark.parametrize(
-    "obs_handler", [StaticObservation, StaticBatchObservation]
-)
+@pytest.mark.parametrize("obs_handler", [StaticObservation, StaticBatchObservation])
 def test_log_prob_exists(model, obs_handler):
     """
     Tests if the log_prob exists at the observed site.
@@ -104,9 +102,7 @@ def test_log_prob_exists(model, obs_handler):
 
 
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
-@pytest.mark.parametrize(
-    "obs_handler", [StaticObservation, StaticBatchObservation]
-)
+@pytest.mark.parametrize("obs_handler", [StaticObservation, StaticBatchObservation])
 def test_tspan_collision(model, obs_handler):
     """
     Tests if observation times that intersect with tspan do not raise an error or create
@@ -125,9 +121,7 @@ def test_tspan_collision(model, obs_handler):
 
 
 @pytest.mark.parametrize("model", [bayes_sir_model])
-@pytest.mark.parametrize(
-    "obs_handler", [StaticObservation, StaticBatchObservation]
-)
+@pytest.mark.parametrize("obs_handler", [StaticObservation, StaticBatchObservation])
 def test_svi_composition_test_one(model, obs_handler):
     data1 = {
         "S_obs": torch.tensor(10.0),


### PR DESCRIPTION
This refactoring PR renames the batched observation handler to something shorter and more consistent with the other interruption handlers.