### PR TITLE
Reorder state and dstate in InPlaceDynamics and ObservableInPlaceDynamics

### DIFF
--- a/chirho/dynamical/ops/dynamical.py
+++ b/chirho/dynamical/ops/dynamical.py
@@ -110,13 +110,13 @@ class Trajectory(Generic[T], State[_Sliceable[T]]):
 
 @runtime_checkable
 class InPlaceDynamics(Protocol[S]):
-    def diff(self, __state: State[S], __dstate: State[S]) -> None:
+    def diff(self, __dstate: State[S], __state: State[S]) -> None:
         ...
 
 
 @runtime_checkable
 class ObservableInPlaceDynamics(InPlaceDynamics[S], Protocol[S]):
-    def diff(self, __state: State[S], __dstate: State[S]) -> None:
+    def diff(self, __dstate: State[S], __state: State[S]) -> None:
         ...
 
     def observation(self, __state: Union[State[S], Trajectory[S]]) -> None:


### PR DESCRIPTION
This tiny PR orders `__dstate` and `__state` in `Dynamics` and `ObservableInPlaceDynamics` to be consistent with existing order in `torchdiffeq` backend, tests, and the demo notebook. I believe this slipped through the cracks in my review of #310 .

Alternatively, we could change the order in backend, tests, and examples.