### PR TITLE
Remove var_order attribute from State interface

### DIFF
--- a/chirho/dynamical/handlers/interruption.py
+++ b/chirho/dynamical/handlers/interruption.py
@@ -61,8 +61,6 @@ class DynamicInterruption(Generic[T], Interruption):
     :param event_f: An event trigger function that approaches and returns 0.0 when the event should be triggered.
         This can be designed to trigger when the current state is "close enough" to some trigger state, or when an
         element of the state exceeds some threshold, etc. It takes both the current time and current state.
-    :param var_order: The full State.var_order. This could be intervention.var_order if the intervention applies
-        to the full state.
     """
 
     def __init__(self, event_f: Callable[[R, State[T]], R]):

--- a/chirho/dynamical/internals/_utils.py
+++ b/chirho/dynamical/internals/_utils.py
@@ -1,5 +1,5 @@
 import functools
-from typing import TypeVar
+from typing import FrozenSet, Tuple, TypeVar
 
 import torch
 
@@ -75,3 +75,8 @@ def _append_tensor(prev_v: torch.Tensor, curr_v: torch.Tensor) -> torch.Tensor:
     prev_v = prev_v.expand(*batch_shape, *prev_v.shape[-1:])
     curr_v = curr_v.expand(*batch_shape, *curr_v.shape[-1:])
     return torch.cat([prev_v, curr_v], dim=time_dim)
+
+
+@functools.cache
+def _var_order(varnames: FrozenSet[str]) -> Tuple[str, ...]:
+    return tuple(sorted(varnames))

--- a/chirho/dynamical/internals/_utils.py
+++ b/chirho/dynamical/internals/_utils.py
@@ -77,6 +77,6 @@ def _append_tensor(prev_v: torch.Tensor, curr_v: torch.Tensor) -> torch.Tensor:
     return torch.cat([prev_v, curr_v], dim=time_dim)
 
 
-@functools.cache
+@functools.lru_cache
 def _var_order(varnames: FrozenSet[str]) -> Tuple[str, ...]:
     return tuple(sorted(varnames))

--- a/chirho/dynamical/internals/backends/torchdiffeq.py
+++ b/chirho/dynamical/internals/backends/torchdiffeq.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Callable, FrozenSet, List, Tuple, TypeVar
+from typing import Callable, List, Tuple, TypeVar
 
 import torch
 import torchdiffeq
@@ -10,6 +10,7 @@ from chirho.dynamical.handlers.interruption import (
     StaticInterruption,
 )
 from chirho.dynamical.handlers.solver import TorchDiffEq
+from chirho.dynamical.internals._utils import _var_order
 from chirho.dynamical.internals.solver import (
     get_next_interruptions_dynamic,
     simulate_point,
@@ -19,11 +20,6 @@ from chirho.dynamical.ops import InPlaceDynamics, State, Trajectory
 
 S = TypeVar("S")
 T = TypeVar("T")
-
-
-@functools.cache
-def _var_order(varnames: FrozenSet[str]) -> Tuple[str, ...]:
-    return tuple(sorted(varnames))
 
 
 # noinspection PyMethodParameters

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -21,10 +21,6 @@ class State(Generic[T]):
             setattr(self, k, v)
 
     @property
-    def var_order(self):
-        return tuple(sorted(self.keys))
-
-    @property
     def keys(self) -> FrozenSet[str]:
         return frozenset(self.__dict__["_values"].keys())
 


### PR DESCRIPTION
This small refactoring PR removes the `State.var_order` attribute (which is an implementation detail of `torchdiffeq`) from the user-facing `State` type and moves it to `chirho.dynamical.internals._utils`.