### PR TITLE
Remove usage of Trajectory.__len__ 

### DIFF
--- a/chirho/dynamical/handlers/interruption.py
+++ b/chirho/dynamical/handlers/interruption.py
@@ -178,6 +178,6 @@ class StaticBatchObservation(Generic[T], LogTrajectory[T]):
         # TODO: Check to make sure that the observations all fall within the outermost `simulate` start and end times.
         # This condition checks whether all of the simulate calls have been executed.
         if len_traj == len(self.times):
-            dynamics: ObservableInPlaceDynamics[torch.Tensor] = msg["args"][0]
+            dynamics: ObservableInPlaceDynamics[T] = msg["args"][0]
             with condition(data=self.data):
                 dynamics.observation(self.trajectory)

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -5,7 +5,7 @@ from typing import FrozenSet, Generic, Optional, Protocol, TypeVar, Union
 import pyro
 import torch
 
-from chirho.indexed.ops import IndexSet, gather, get_index_plates, indices_of
+from chirho.indexed.ops import IndexSet, gather, get_index_plates
 
 R = Union[numbers.Real, torch.Tensor]
 S = TypeVar("S")
@@ -53,15 +53,6 @@ class _Sliceable(Protocol[T_co]):
 
 
 class Trajectory(Generic[T], State[_Sliceable[T]]):
-    def __len__(self) -> int:
-        if not self.keys:
-            return 0
-
-        name_to_dim = {k: f.dim - 1 for k, f in get_index_plates().items()}
-        name_to_dim["__time"] = -1
-        # TODO support event_dim > 0
-        return len(indices_of(self, event_dim=0, name_to_dim=name_to_dim)["__time"])
-
     def __getitem__(self, key: torch.Tensor) -> "Trajectory[T]":
         assert key.dtype == torch.bool
 


### PR DESCRIPTION
As part of addressing #321, this refactoring PR removes the `Trajectory.__len__` method. This is only used in one place, so I moved the existing logic there, and even that should not be necessary once the interaction of `LogTrajectory` and `InterruptionEventLoop` is cleaned up later.