### PR TITLE
Fix generic types and arguments of LogTrajectory and StaticBatchObservation

### DIFF
--- a/chirho/dynamical/handlers/interruption.py
+++ b/chirho/dynamical/handlers/interruption.py
@@ -147,30 +147,21 @@ class DynamicIntervention(Generic[T], DynamicInterruption, _InterventionMixin[T]
         super().__init__(event_f)
 
 
-class StaticBatchObservation(LogTrajectory):
+class StaticBatchObservation(Generic[T], LogTrajectory[T]):
+    data: Dict[str, Observation[T]]
+
     def __init__(
         self,
         times: torch.Tensor,
-        data: Dict[str, torch.Tensor],
+        data: Dict[str, Observation[T]],
+        *,
         eps: float = 1e-6,
     ):
         self.data = data
-        # Add a small amount of time to the observation time to ensure that
-        # the observation occurs after the logging period.
-        self.times = times + eps
-
-        # Require that each data element maps 1:1 with the times.
-        if not all(len(v) == len(times) for v in data.values()):
-            raise ValueError(
-                f"Each data element must have the same length as the passed times. Got lengths "
-                f"{[len(v) for v in data.values()]} for data elements {[k for k in data.keys()]}, but "
-                f"expected length {len(times)}."
-            )
-
-        super().__init__(times)
+        super().__init__(times, eps=eps)
 
     def _pyro_post_simulate(self, msg) -> None:
-        dynamics: ObservableInPlaceDynamics[torch.Tensor] = msg["args"][0]
+        dynamics: ObservableInPlaceDynamics[T] = msg["args"][0]
 
         if "in_SEL" not in msg.keys():
             msg["in_SEL"] = False

--- a/chirho/dynamical/handlers/trajectory.py
+++ b/chirho/dynamical/handlers/trajectory.py
@@ -36,7 +36,7 @@ class LogTrajectory(Generic[T], pyro.poutine.messenger.Messenger):
         # Turn a simulate that returns a state into a simulate that returns a trajectory at each of the logging_times
         dynamics, initial_state, start_time, end_time = msg["args"]
         if msg["kwargs"].get("solver", None) is not None:
-            solver: Solver = typing.cast(Solver, msg["kwargs"]["solver"])
+            solver = typing.cast(Solver, msg["kwargs"]["solver"])
         else:
             solver = get_solver()
 

--- a/chirho/dynamical/handlers/trajectory.py
+++ b/chirho/dynamical/handlers/trajectory.py
@@ -1,10 +1,11 @@
+import typing
 from typing import Generic, TypeVar
 
 import pyro
 import torch
 
 from chirho.dynamical.internals._utils import append
-from chirho.dynamical.internals.solver import simulate_trajectory
+from chirho.dynamical.internals.solver import Solver, get_solver, simulate_trajectory
 from chirho.dynamical.ops import Trajectory
 
 T = TypeVar("T")
@@ -13,24 +14,19 @@ T = TypeVar("T")
 class LogTrajectory(Generic[T], pyro.poutine.messenger.Messenger):
     trajectory: Trajectory[T]
 
-    def __init__(self, logging_times: torch.Tensor, epsilon: float = 1e-6):
+    def __init__(self, times: torch.Tensor, *, eps: float = 1e-6):
         # Adding epsilon to the logging times to avoid collision issues with the logging times being exactly on the
         #  boundaries of the simulation times. This is a hack, but it's a hack that should work for now.
-        self.logging_times = logging_times + epsilon
-        self._reset()
+        self.times = times + eps
 
         # Require that the times are sorted. This is required by the index masking we do below.
-        # TODO AZ sort this here (and the data too) accordingly?
-        if not torch.all(self.logging_times[1:] > self.logging_times[:-1]):
+        if not torch.all(self.times[1:] > self.times[:-1]):
             raise ValueError("The passed times must be sorted.")
 
         super().__init__()
 
-    def _reset(self) -> None:
+    def __enter__(self) -> "LogTrajectory[T]":
         self.trajectory: Trajectory[T] = Trajectory()
-
-    def __enter__(self):
-        self._reset()
         return super().__enter__()
 
     def _pyro_simulate(self, msg) -> None:
@@ -39,14 +35,13 @@ class LogTrajectory(Generic[T], pyro.poutine.messenger.Messenger):
     def _pyro_post_simulate(self, msg) -> None:
         # Turn a simulate that returns a state into a simulate that returns a trajectory at each of the logging_times
         dynamics, initial_state, start_time, end_time = msg["args"]
-        if "solver" in msg["kwargs"]:
-            solver = msg["kwargs"]["solver"]
+        if msg["kwargs"].get("solver", None) is not None:
+            solver: Solver = typing.cast(Solver, msg["kwargs"]["solver"])
         else:
-            # Early return to trigger `simulate` ValueError for not having a solver.
-            return
+            solver = get_solver()
 
-        filtered_timespan = self.logging_times[
-            (self.logging_times >= start_time) & (self.logging_times <= end_time)
+        filtered_timespan = self.times[
+            (self.times >= start_time) & (self.times <= end_time)
         ]
         timespan = torch.concat(
             (start_time.unsqueeze(-1), filtered_timespan, end_time.unsqueeze(-1))
@@ -61,7 +56,7 @@ class LogTrajectory(Generic[T], pyro.poutine.messenger.Messenger):
         idx = (timespan > timespan[0]) & (timespan < timespan[-1])
         if idx.any():
             self.trajectory: Trajectory[T] = append(self.trajectory, trajectory[idx])
-        if idx.sum() > len(self.logging_times):
+        if idx.sum() > len(self.times):
             raise ValueError(
                 "Multiple simulates were used with a single LogTrajectory handler."
                 "This is currently not supported."

--- a/tests/dynamical/test_dynamic_interventions.py
+++ b/tests/dynamical/test_dynamic_interventions.py
@@ -81,7 +81,7 @@ def test_nested_dynamic_intervention_causes_change(
     ts1, ts2 = trigger_states
     is1, is2 = intervene_states
     with LogTrajectory(
-        logging_times=logging_times,
+        times=logging_times,
     ) as dt:
         with InterruptionEventLoop():
             with DynamicIntervention(
@@ -157,7 +157,7 @@ def test_dynamic_intervention_causes_change(
     intervene_state,
 ):
     with LogTrajectory(
-        logging_times=logging_times,
+        times=logging_times,
     ) as dt:
         with InterruptionEventLoop():
             with DynamicIntervention(
@@ -216,7 +216,7 @@ def test_split_twinworld_dynamic_intervention(
 
     # Simulate with the intervention and ensure that the result differs from the observational execution.
     with LogTrajectory(
-        logging_times=logging_times,
+        times=logging_times,
     ) as dt:
         with InterruptionEventLoop():
             with DynamicIntervention(
@@ -264,7 +264,7 @@ def test_split_multiworld_dynamic_intervention(
 
     # Simulate with the intervention and ensure that the result differs from the observational execution.
     with LogTrajectory(
-        logging_times=logging_times,
+        times=logging_times,
     ) as dt:
         with InterruptionEventLoop():
             with DynamicIntervention(

--- a/tests/dynamical/test_log_trajectory.py
+++ b/tests/dynamical/test_log_trajectory.py
@@ -24,12 +24,12 @@ logging_times = torch.tensor([1.0, 2.0, 3.0])
 def test_logging():
     sir = bayes_sir_model()
     with LogTrajectory(
-        logging_times=logging_times,
+        times=logging_times,
     ) as dt1:
         result1 = simulate(sir, init_state, start_time, end_time, solver=TorchDiffEq())
 
     with LogTrajectory(
-        logging_times=logging_times,
+        times=logging_times,
     ) as dt2:
         with InterruptionEventLoop():
             result2 = simulate(

--- a/tests/dynamical/test_static_interventions.py
+++ b/tests/dynamical/test_static_interventions.py
@@ -66,13 +66,13 @@ def test_point_intervention_causes_difference(
     intervene_time,
 ):
     with LogTrajectory(
-        logging_times=logging_times,
+        times=logging_times,
     ) as observational_dt:
         simulate(model, init_state, start_time, end_time, solver=TorchDiffEq())
 
     # Simulate with the intervention and ensure that the result differs from the observational execution.
     with LogTrajectory(
-        logging_times=logging_times,
+        times=logging_times,
     ) as intervened_dt:
         with InterruptionEventLoop():
             with StaticIntervention(time=intervene_time, intervention=intervene_state):
@@ -142,13 +142,13 @@ def test_nested_point_interventions_cause_difference(
     intervene_time2,
 ):
     with LogTrajectory(
-        logging_times=logging_times,
+        times=logging_times,
     ) as observational_dt:
         simulate(model, init_state, start_time, end_time, solver=TorchDiffEq())
 
     # Simulate with the intervention and ensure that the result differs from the observational execution.
     with LogTrajectory(
-        logging_times=logging_times,
+        times=logging_times,
     ) as intervened_dt:
         with InterruptionEventLoop():
             with StaticIntervention(
@@ -209,7 +209,7 @@ def test_twinworld_point_intervention(
 ):
     # Simulate with the intervention and ensure that the result differs from the observational execution.
     with LogTrajectory(
-        logging_times=logging_times,
+        times=logging_times,
     ) as dt:
         with InterruptionEventLoop():
             with StaticIntervention(time=intervene_time, intervention=intervene_state):
@@ -244,7 +244,7 @@ def test_multiworld_point_intervention(
 ):
     # Simulate with the intervention and ensure that the result differs from the observational execution.
     with LogTrajectory(
-        logging_times=logging_times,
+        times=logging_times,
     ) as dt:
         with InterruptionEventLoop():
             with StaticIntervention(time=intervene_time, intervention=intervene_state):
@@ -278,7 +278,7 @@ def test_split_odeint_broadcast(
     model, init_state, start_time, end_time, intervene_state, intervene_time
 ):
     with LogTrajectory(
-        logging_times=logging_times,
+        times=logging_times,
     ) as dt:
         with TwinWorldCounterfactual() as cf:
             cf_init_state = intervene(init_state_values, intervene_state, event_dim=0)


### PR DESCRIPTION
This refactoring PR includes a few minor fixes for the interfaces of `LogTrajectory` and `StaticBatchObservation` to make them consistent with each other and the rest of the module.