### PR TITLE
Remove Trajectory.__getitem__ method

### DIFF
--- a/chirho/dynamical/handlers/trajectory.py
+++ b/chirho/dynamical/handlers/trajectory.py
@@ -60,6 +60,7 @@ class LogTrajectory(Generic[T], pyro.poutine.messenger.Messenger):
             timespan,
         )
 
+        # TODO support dim != -1
         idx_name = "__time"
         name_to_dim = {k: f.dim - 1 for k, f in get_index_plates().items()}
         name_to_dim[idx_name] = -1

--- a/chirho/dynamical/handlers/trajectory.py
+++ b/chirho/dynamical/handlers/trajectory.py
@@ -6,6 +6,7 @@ import torch
 from chirho.dynamical.internals._utils import append
 from chirho.dynamical.internals.solver import simulate_trajectory
 from chirho.dynamical.ops import Trajectory
+from chirho.indexed.ops import IndexSet, gather, get_index_plates
 
 T = TypeVar("T")
 
@@ -58,12 +59,16 @@ class LogTrajectory(Generic[T], pyro.poutine.messenger.Messenger):
             initial_state,
             timespan,
         )
-        idx = (timespan > timespan[0]) & (timespan < timespan[-1])
-        if idx.any():
-            self.trajectory: Trajectory[T] = append(self.trajectory, trajectory[idx])
-        if idx.sum() > len(self.logging_times):
-            raise ValueError(
-                "Multiple simulates were used with a single LogTrajectory handler."
-                "This is currently not supported."
-            )
-        msg["value"] = trajectory[timespan == timespan[-1]].to_state()
+
+        idx_name = "__time"
+        name_to_dim = {k: f.dim - 1 for k, f in get_index_plates().items()}
+        name_to_dim[idx_name] = -1
+
+        if len(timespan) > 2:
+            part_idx = IndexSet(**{idx_name: set(range(1, len(timespan) - 1))})
+            new_part = gather(trajectory, part_idx, name_to_dim=name_to_dim)
+            self.trajectory: Trajectory[T] = append(self.trajectory, new_part)
+
+        final_idx = IndexSet(**{idx_name: {len(timespan) - 1}})
+        final_state = gather(trajectory, final_idx, name_to_dim=name_to_dim)
+        msg["value"] = final_state.to_state()

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -5,7 +5,7 @@ from typing import FrozenSet, Generic, Optional, Protocol, TypeVar, Union
 import pyro
 import torch
 
-from chirho.indexed.ops import IndexSet, gather, get_index_plates, indices_of
+from chirho.indexed.ops import IndexSet, gather, get_index_plates
 
 R = Union[numbers.Real, torch.Tensor]
 S = TypeVar("S")
@@ -53,15 +53,6 @@ class _Sliceable(Protocol[T_co]):
 
 
 class Trajectory(Generic[T], State[_Sliceable[T]]):
-    def __len__(self) -> int:
-        if not self.keys:
-            return 0
-
-        name_to_dim = {k: f.dim - 1 for k, f in get_index_plates().items()}
-        name_to_dim["__time"] = -1
-        # TODO support event_dim > 0
-        return len(indices_of(self, event_dim=0, name_to_dim=name_to_dim)["__time"])
-
     def __getitem__(self, key: torch.Tensor) -> "Trajectory[T]":
         assert key.dtype == torch.bool
 

--- a/tests/dynamical/test_dynamic_interventions.py
+++ b/tests/dynamical/test_dynamic_interventions.py
@@ -108,7 +108,9 @@ def test_nested_dynamic_intervention_causes_change(
 
     # TODO support dim != -1
     name_to_dim = {"__time": -1}
-    preint_idx = IndexSet(__time=set(i for i in range(len(preint_mask)) if preint_mask[i]))
+    preint_idx = IndexSet(
+        __time=set(i for i in range(len(preint_mask)) if preint_mask[i])
+    )
 
     # Make sure all points before the intervention maintain the same total population.
     preint_traj = gather(trajectory, preint_idx, name_to_dim=name_to_dim)
@@ -129,9 +131,17 @@ def test_nested_dynamic_intervention_causes_change(
         postsec_int_mask
     ), "trivial test case"
 
-    postfirst_int_presec_int_idx = IndexSet(__time=set(i for i in range(len(postfirst_int_presec_int_mask)) if postfirst_int_presec_int_mask[i]))
+    postfirst_int_presec_int_idx = IndexSet(
+        __time=set(
+            i
+            for i in range(len(postfirst_int_presec_int_mask))
+            if postfirst_int_presec_int_mask[i]
+        )
+    )
 
-    postfirst_int_presec_int_traj = gather(trajectory, postfirst_int_presec_int_idx, name_to_dim=name_to_dim)
+    postfirst_int_presec_int_traj = gather(
+        trajectory, postfirst_int_presec_int_idx, name_to_dim=name_to_dim
+    )
     assert torch.all(
         postfirst_int_presec_int_traj.S
         + postfirst_int_presec_int_traj.I
@@ -139,7 +149,9 @@ def test_nested_dynamic_intervention_causes_change(
         > (preint_total + firstis.S) * 0.95
     )
 
-    postsec_int_idx = IndexSet(__time=set(i for i in range(len(postsec_int_mask)) if postsec_int_mask[i]))
+    postsec_int_idx = IndexSet(
+        __time=set(i for i in range(len(postsec_int_mask)) if postsec_int_mask[i])
+    )
 
     postsec_int_traj = gather(trajectory, postsec_int_idx, name_to_dim=name_to_dim)
     assert torch.all(
@@ -187,8 +199,12 @@ def test_dynamic_intervention_causes_change(
     # TODO support dim != -1
     name_to_dim = {"__time": -1}
 
-    preint_idx = IndexSet(__time=set(i for i in range(len(postint_mask)) if not postint_mask[i]))
-    postint_idx = IndexSet(__time=set(i for i in range(len(postint_mask)) if postint_mask[i]))
+    preint_idx = IndexSet(
+        __time=set(i for i in range(len(postint_mask)) if not postint_mask[i])
+    )
+    postint_idx = IndexSet(
+        __time=set(i for i in range(len(postint_mask)) if postint_mask[i])
+    )
 
     postint_traj = gather(trajectory, postint_idx, name_to_dim=name_to_dim)
     preint_traj = gather(trajectory, preint_idx, name_to_dim=name_to_dim)

--- a/tests/dynamical/test_static_interventions.py
+++ b/tests/dynamical/test_static_interventions.py
@@ -118,7 +118,7 @@ def test_point_intervention_causes_difference(
     intervened_trajectory_before_int = gather(
         intervened_trajectory, before_idx, name_to_dim=name_to_dim
     )
-    assert check_trajectories_match(
+    assert after.all() or check_trajectories_match(
         observational_trajectory_before_int, intervened_trajectory_before_int
     )
 
@@ -128,7 +128,7 @@ def test_point_intervention_causes_difference(
     intervened_trajectory_after_int = gather(
         intervened_trajectory, after_idx, name_to_dim=name_to_dim
     )
-    assert check_trajectories_match_in_all_but_values(
+    assert before.all() or check_trajectories_match_in_all_but_values(
         observational_trajectory_after_int, intervened_trajectory_after_int
     )
 

--- a/tests/dynamical/test_static_interventions.py
+++ b/tests/dynamical/test_static_interventions.py
@@ -106,14 +106,20 @@ def test_point_intervention_causes_difference(
 
     assert torch.any(before) or torch.any(after), "trivial test case"
 
-    observational_trajectory_before_int = observational_trajectory[before]
-    intervened_trajectory_before_int = intervened_trajectory[before]
+    # TODO support dim != -1
+    name_to_dim = {"__time": -1}
+
+    before_idx = IndexSet(__time={i for i in range(len(before)) if before[i]})
+    after_idx = IndexSet(__time={i for i in range(len(after)) if after[i]})
+
+    observational_trajectory_before_int = gather(observational_trajectory, before_idx, name_to_dim=name_to_dim)
+    intervened_trajectory_before_int = gather(intervened_trajectory, before_idx, name_to_dim=name_to_dim)
     assert check_trajectories_match(
         observational_trajectory_before_int, intervened_trajectory_before_int
     )
 
-    observational_trajectory_after_int = observational_trajectory[after]
-    intervened_trajectory_after_int = intervened_trajectory[after]
+    observational_trajectory_after_int = gather(observational_trajectory, after_idx, name_to_dim=name_to_dim)
+    intervened_trajectory_after_int = gather(intervened_trajectory, after_idx, name_to_dim=name_to_dim)
     assert check_trajectories_match_in_all_but_values(
         observational_trajectory_after_int, intervened_trajectory_after_int
     )

--- a/tests/dynamical/test_static_interventions.py
+++ b/tests/dynamical/test_static_interventions.py
@@ -112,14 +112,22 @@ def test_point_intervention_causes_difference(
     before_idx = IndexSet(__time={i for i in range(len(before)) if before[i]})
     after_idx = IndexSet(__time={i for i in range(len(after)) if after[i]})
 
-    observational_trajectory_before_int = gather(observational_trajectory, before_idx, name_to_dim=name_to_dim)
-    intervened_trajectory_before_int = gather(intervened_trajectory, before_idx, name_to_dim=name_to_dim)
+    observational_trajectory_before_int = gather(
+        observational_trajectory, before_idx, name_to_dim=name_to_dim
+    )
+    intervened_trajectory_before_int = gather(
+        intervened_trajectory, before_idx, name_to_dim=name_to_dim
+    )
     assert check_trajectories_match(
         observational_trajectory_before_int, intervened_trajectory_before_int
     )
 
-    observational_trajectory_after_int = gather(observational_trajectory, after_idx, name_to_dim=name_to_dim)
-    intervened_trajectory_after_int = gather(intervened_trajectory, after_idx, name_to_dim=name_to_dim)
+    observational_trajectory_after_int = gather(
+        observational_trajectory, after_idx, name_to_dim=name_to_dim
+    )
+    intervened_trajectory_after_int = gather(
+        intervened_trajectory, after_idx, name_to_dim=name_to_dim
+    )
     assert check_trajectories_match_in_all_but_values(
         observational_trajectory_after_int, intervened_trajectory_after_int
     )


### PR DESCRIPTION
~~Blocked by #323~~

As part of addressing #321, this refactoring PR removes the `__getitem__` method of the `Trajectory` type, replacing it with a call to `chirho.indexed.ops.gather` as in the current implementation of `__getitem__`. This method was only used in two places in the code and a couple of unit tests, so the change isn't actually too big.