### PR TITLE
Separate Observable from InPlaceDynamics interface

### DIFF
--- a/chirho/dynamical/handlers/interruption.py
+++ b/chirho/dynamical/handlers/interruption.py
@@ -6,7 +6,7 @@ import pyro
 import torch
 
 from chirho.dynamical.handlers.trajectory import LogTrajectory
-from chirho.dynamical.ops import ObservableInPlaceDynamics, State
+from chirho.dynamical.ops import Observable, State
 from chirho.indexed.ops import get_index_plates, indices_of
 from chirho.interventional.ops import Intervention, intervene
 from chirho.observational.handlers import condition
@@ -90,7 +90,7 @@ class _PointObservationMixin(Generic[T]):
     time: R
 
     def _pyro_apply_interruptions(self, msg) -> None:
-        dynamics: ObservableInPlaceDynamics[T] = msg["args"][0]
+        dynamics: Observable[T] = msg["args"][0]
         current_state: State[T] = msg["args"][1]
 
         with condition(data=self.data):
@@ -178,6 +178,6 @@ class StaticBatchObservation(Generic[T], LogTrajectory[T]):
         # TODO: Check to make sure that the observations all fall within the outermost `simulate` start and end times.
         # This condition checks whether all of the simulate calls have been executed.
         if len_traj == len(self.times):
-            dynamics: ObservableInPlaceDynamics[T] = msg["args"][0]
+            dynamics: Observable[T] = msg["args"][0]
             with condition(data=self.data):
                 dynamics.observation(self.trajectory)

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -73,7 +73,7 @@ class Trajectory(Generic[T], State[_Sliceable[T]]):
 
 @typing.runtime_checkable
 class Observable(Protocol[S]):
-    def observation(self, __state: State[S]) -> None:
+    def observation(self, __state: Union[State[S], Trajectory[S]]) -> None:
         ...
 
 

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -72,17 +72,14 @@ class Trajectory(Generic[T], State[_Sliceable[T]]):
 
 
 @typing.runtime_checkable
-class InPlaceDynamics(Protocol[S]):
-    def diff(self, __dstate: State[S], __state: State[S]) -> None:
+class Observable(Protocol[S]):
+    def observation(self, __state: State[S]) -> None:
         ...
 
 
 @typing.runtime_checkable
-class ObservableInPlaceDynamics(InPlaceDynamics[S], Protocol[S]):
+class InPlaceDynamics(Protocol[S]):
     def diff(self, __dstate: State[S], __state: State[S]) -> None:
-        ...
-
-    def observation(self, __state: Union[State[S], Trajectory[S]]) -> None:
         ...
 
 

--- a/tests/dynamical/dynamical_fixtures.py
+++ b/tests/dynamical/dynamical_fixtures.py
@@ -4,12 +4,12 @@ import pyro
 import torch
 from pyro.distributions import Normal, Uniform, constraints
 
-from chirho.dynamical.ops import InPlaceDynamics, State, Trajectory
+from chirho.dynamical.ops import State, Trajectory
 
 T = TypeVar("T")
 
 
-class UnifiedFixtureDynamics(InPlaceDynamics):
+class UnifiedFixtureDynamics:
     def __init__(self, beta=None, gamma=None):
         super().__init__()
 


### PR DESCRIPTION
This small refactoring PR makes the `.observation` and `Dynamics` interfaces of `ObservableInPlaceDynamics` orthogonal, as a preliminary to possibly making the `Dynamics` interface functional by default.