### PR TITLE
Encapsulate `time` in `State` and remove `start_time` argument from `simulate`

### DIFF
--- a/chirho/dynamical/handlers/interruption.py
+++ b/chirho/dynamical/handlers/interruption.py
@@ -173,7 +173,7 @@ class StaticBatchObservation(Generic[T], LogTrajectory[T]):
         name_to_dim["__time"] = -1
         len_traj = (
             0
-            if not get_keys(self.trajectory)
+            if not get_keys(self.trajectory, include_time=False)
             else 1 + max(indices_of(self.trajectory, name_to_dim=name_to_dim)["__time"])
         )
 

--- a/chirho/dynamical/handlers/interruption.py
+++ b/chirho/dynamical/handlers/interruption.py
@@ -36,7 +36,8 @@ class StaticInterruption(Interruption):
         super().__init__()
 
     def _pyro_simulate_to_interruption(self, msg) -> None:
-        _, _, _, start_time, end_time = msg["args"]
+        start_time: R = msg["args"][2].time
+        end_time: R = msg["args"][3]
 
         if start_time < self.time < end_time:
             next_static_interruption: Optional[StaticInterruption] = msg["kwargs"].get(

--- a/chirho/dynamical/internals/_utils.py
+++ b/chirho/dynamical/internals/_utils.py
@@ -35,8 +35,8 @@ def _gather_state(
 
 @intervene.register(State)
 def _state_intervene(obs: State[T], act: State[T], **kwargs) -> State[T]:
-    new_state: State[T] = State()
-    for k in get_keys(obs):
+    new_state: State[T] = State(time=obs.time)
+    for k in get_keys(obs, include_time=False):
         setattr(
             new_state, k, intervene(getattr(obs, k), getattr(act, k, None), **kwargs)
         )
@@ -50,13 +50,13 @@ def append(fst, rest: T) -> T:
 
 @append.register(State)
 def _append_trajectory(traj1: State[T], traj2: State[T]) -> State[T]:
-    if len(get_keys(traj1)) == 0:
+    if len(get_keys(traj1, include_time=False)) == 0:
         return traj2
 
-    if len(get_keys(traj2)) == 0:
+    if len(get_keys(traj2, include_time=False)) == 0:
         return traj1
 
-    if get_keys(traj1) != get_keys(traj2):
+    if get_keys(traj1, include_time=False) != get_keys(traj2, include_time=False):
         raise ValueError(
             f"Trajectories must have the same keys to be appended, but got {get_keys(traj1)} and {get_keys(traj2)}."
         )

--- a/chirho/dynamical/internals/backends/torchdiffeq.py
+++ b/chirho/dynamical/internals/backends/torchdiffeq.py
@@ -30,7 +30,7 @@ def _deriv(
     time: torch.Tensor,
     state: Tuple[torch.Tensor, ...],
 ) -> Tuple[torch.Tensor, ...]:
-    ddt: State[torch.Tensor] = State(time=time)
+    ddt: State[torch.Tensor] = State()
     env: State[torch.Tensor] = State(time=time)
     for var, value in zip(var_order, state):
         setattr(env, var, value)

--- a/chirho/dynamical/internals/backends/torchdiffeq.py
+++ b/chirho/dynamical/internals/backends/torchdiffeq.py
@@ -112,6 +112,8 @@ def torchdiffeq_ode_simulate_point(
     initial_state: State[torch.Tensor],
     end_time: torch.Tensor,
 ) -> State[torch.Tensor]:
+    assert initial_state.time is not None
+
     timespan = torch.stack((initial_state.time, end_time))
     trajectory = _torchdiffeq_ode_simulate_inner(
         dynamics, initial_state, timespan, **solver.odeint_kwargs
@@ -149,6 +151,8 @@ def torchdiffeq_get_next_interruptions_dynamic(
     dynamic_interruptions: List[DynamicInterruption],
     **kwargs,
 ) -> Tuple[Tuple[Interruption, ...], torch.Tensor]:
+    assert start_state.time is not None
+
     var_order = _var_order(
         get_keys(start_state, include_time=False)
     )  # arbitrary, but fixed

--- a/chirho/dynamical/internals/backends/torchdiffeq.py
+++ b/chirho/dynamical/internals/backends/torchdiffeq.py
@@ -149,7 +149,9 @@ def torchdiffeq_get_next_interruptions_dynamic(
     dynamic_interruptions: List[DynamicInterruption],
     **kwargs,
 ) -> Tuple[Tuple[Interruption, ...], torch.Tensor]:
-    var_order = _var_order(get_keys(start_state, include_time=False))  # arbitrary, but fixed
+    var_order = _var_order(
+        get_keys(start_state, include_time=False)
+    )  # arbitrary, but fixed
 
     # Create the event function combining all dynamic events and the terminal (next) static interruption.
     combined_event_f = torchdiffeq_combined_event_f(

--- a/chirho/dynamical/internals/solver.py
+++ b/chirho/dynamical/internals/solver.py
@@ -44,7 +44,6 @@ def simulate_point(
     solver: Solver,
     dynamics: InPlaceDynamics[T],
     initial_state: State[T],
-    start_time: R,
     end_time: R,
     **kwargs,
 ) -> State[T]:
@@ -78,7 +77,6 @@ def simulate_to_interruption(
     solver: Solver,
     dynamics: InPlaceDynamics[T],
     start_state: State[T],
-    start_time: R,
     end_time: R,
     *,
     next_static_interruption: Optional[StaticInterruption] = None,
@@ -96,7 +94,6 @@ def simulate_to_interruption(
         solver,
         dynamics,
         start_state,
-        start_time,
         end_time,
         next_static_interruption=next_static_interruption,
         dynamic_interruptions=dynamic_interruptions,
@@ -105,11 +102,9 @@ def simulate_to_interruption(
     # TODO: consider memoizing results of `get_next_interruptions` to avoid recomputing
     #  the solver in the dynamic setting. The interactions are a bit tricky here though, as we couldn't be in
     #  a LogTrajectory context.
-    event_state = simulate(
-        dynamics, start_state, start_time, interruption_time, solver=solver
-    )
+    event_state = simulate(dynamics, start_state, interruption_time, solver=solver)
 
-    return event_state, interruptions, interruption_time
+    return event_state, interruptions
 
 
 @pyro.poutine.runtime.effectful(type="apply_interruptions")
@@ -127,7 +122,6 @@ def get_next_interruptions(
     solver: Solver,
     dynamics: InPlaceDynamics[T],
     start_state: State[T],
-    start_time: R,
     end_time: R,
     *,
     next_static_interruption: Optional[StaticInterruption] = None,
@@ -151,7 +145,6 @@ def get_next_interruptions(
             solver,
             dynamics,
             start_state,
-            start_time,
             next_static_interruption=next_static_interruption,
             dynamic_interruptions=dynamic_interruptions,
             **kwargs,
@@ -163,7 +156,6 @@ def get_next_interruptions_dynamic(
     solver: Solver,
     dynamics: InPlaceDynamics[T],
     start_state: State[T],
-    start_time: R,
     next_static_interruption: StaticInterruption,
     dynamic_interruptions: List[DynamicInterruption],
 ) -> Tuple[Tuple[Interruption, ...], R]:

--- a/chirho/dynamical/internals/solver.py
+++ b/chirho/dynamical/internals/solver.py
@@ -82,7 +82,7 @@ def simulate_to_interruption(
     next_static_interruption: Optional[StaticInterruption] = None,
     dynamic_interruptions: List[DynamicInterruption] = [],
     **kwargs,
-) -> Tuple[State[T], Tuple[Interruption, ...], R]:
+) -> Tuple[State[T], Tuple[Interruption, ...]]:
     """
     Simulate a dynamical system until the next interruption. This will be either one of the passed
     dynamic interruptions, the next static interruption, or the end time, whichever comes first.

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -13,8 +13,7 @@ T = TypeVar("T")
 class State(Generic[T]):
     def __init__(self, time: Optional[T] = None, **values: T):
         self.__dict__["_values"] = {}
-        if time is not None:
-            self.time = time
+        self.time = time
         for k, v in values.items():
             setattr(self, k, v)
 

--- a/tests/dynamical/dynamical_fixtures.py
+++ b/tests/dynamical/dynamical_fixtures.py
@@ -23,7 +23,7 @@ class UnifiedFixtureDynamics:
 
     def diff(self, dX: State[torch.Tensor], X: State[torch.Tensor]):
         beta = self.beta * (
-            1.0 + 0.1 * torch.sin(0.1 * X.t)
+            1.0 + 0.1 * torch.sin(0.1 * X.time)
         )  # beta oscilates slowly in time.
 
         dX.S = -beta * X.S * X.I
@@ -72,7 +72,7 @@ def check_trajectories_match_in_all_but_values(
 ):
     assert check_keys_match(traj1, traj2)
 
-    for k in get_keys(traj1):
+    for k in get_keys(traj1, include_time=False):
         assert not torch.allclose(
             getattr(traj2, k), getattr(traj1, k)
         ), f"Trajectories are identical in state trajectory of variable {k}, but should differ."

--- a/tests/dynamical/test_dynamic_interventions.py
+++ b/tests/dynamical/test_dynamic_interventions.py
@@ -22,7 +22,12 @@ from .dynamical_fixtures import UnifiedFixtureDynamics
 logger = logging.getLogger(__name__)
 
 # Initial state of the system.
-init_state = State(time=torch.tensor(0.0), S=torch.tensor(50.0), I=torch.tensor(3.0), R=torch.tensor(0.0))
+init_state = State(
+    time=torch.tensor(0.0),
+    S=torch.tensor(50.0),
+    I=torch.tensor(3.0),
+    R=torch.tensor(0.0),
+)
 
 # Points at which to measure the state of the system.
 end_time = torch.tensor(10.0)
@@ -89,9 +94,7 @@ def test_nested_dynamic_intervention_causes_change(
                     event_f=get_state_reached_event_f(ts2),
                     intervention=is2,
                 ):
-                    simulate(
-                        model, init_state, end_time, solver=TorchDiffEq()
-                    )
+                    simulate(model, init_state, end_time, solver=TorchDiffEq())
 
     preint_total = init_state.S + init_state.I + init_state.R
 
@@ -358,9 +361,7 @@ def test_split_twinworld_dynamic_matches_output(
                 )
 
     with InterruptionEventLoop():
-        factual_expected = simulate(
-            model, init_state, end_time, solver=TorchDiffEq()
-        )
+        factual_expected = simulate(model, init_state, end_time, solver=TorchDiffEq())
 
     with cf:
         factual_indices = IndexSet(

--- a/tests/dynamical/test_handler_composition.py
+++ b/tests/dynamical/test_handler_composition.py
@@ -23,7 +23,12 @@ from tests.dynamical.dynamical_fixtures import (
 logger = logging.getLogger(__name__)
 
 # Global variables for tests
-init_state = State(time=torch.tensor(0.0), S=torch.tensor(10.0), I=torch.tensor(1.0), R=torch.tensor(0.0))
+init_state = State(
+    time=torch.tensor(0.0),
+    S=torch.tensor(10.0),
+    I=torch.tensor(1.0),
+    R=torch.tensor(0.0),
+)
 end_time = torch.tensor(1.2)
 logging_times = torch.tensor([0.3, 0.6, 0.9])
 

--- a/tests/dynamical/test_handler_composition.py
+++ b/tests/dynamical/test_handler_composition.py
@@ -23,8 +23,7 @@ from tests.dynamical.dynamical_fixtures import (
 logger = logging.getLogger(__name__)
 
 # Global variables for tests
-init_state = State(S=torch.tensor(10.0), I=torch.tensor(1.0), R=torch.tensor(0.0))
-start_time = torch.tensor(0.0)
+init_state = State(time=torch.tensor(0.0), S=torch.tensor(10.0), I=torch.tensor(1.0), R=torch.tensor(0.0))
 end_time = torch.tensor(1.2)
 logging_times = torch.tensor([0.3, 0.6, 0.9])
 
@@ -66,7 +65,6 @@ def counterf_model():
                 return simulate(
                     UnifiedFixtureDynamicsReparam(beta=0.5, gamma=0.7),
                     init_state,
-                    start_time,
                     end_time,
                     solver=TorchDiffEq(),
                 )

--- a/tests/dynamical/test_log_trajectory.py
+++ b/tests/dynamical/test_log_trajectory.py
@@ -15,7 +15,12 @@ pyro.settings.set(module_local_params=True)
 logger = logging.getLogger(__name__)
 
 # Global variables for tests
-init_state = State(time=torch.tensor(0.0), S=torch.tensor(1.0), I=torch.tensor(2.0), R=torch.tensor(3.3))
+init_state = State(
+    time=torch.tensor(0.0),
+    S=torch.tensor(1.0),
+    I=torch.tensor(2.0),
+    R=torch.tensor(3.3),
+)
 end_time = torch.tensor(4.0)
 logging_times = torch.tensor([1.0, 2.0, 3.0])
 
@@ -31,9 +36,7 @@ def test_logging():
         times=logging_times,
     ) as dt2:
         with InterruptionEventLoop():
-            result2 = simulate(
-                sir, init_state, end_time, solver=TorchDiffEq()
-            )
+            result2 = simulate(sir, init_state, end_time, solver=TorchDiffEq())
     result3 = simulate(sir, init_state, end_time, solver=TorchDiffEq())
 
     assert isinstance(result1, State)

--- a/tests/dynamical/test_log_trajectory.py
+++ b/tests/dynamical/test_log_trajectory.py
@@ -51,15 +51,24 @@ def test_logging():
 
 
 def test_trajectory_methods():
-    trajectory = State(time=torch.tensor([0.0, 1.0, 2.0]), S=torch.tensor([1.0, 2.0, 3.0]))
+    trajectory = State(
+        time=torch.tensor([0.0, 1.0, 2.0]), S=torch.tensor([1.0, 2.0, 3.0])
+    )
     assert get_keys(trajectory, include_time=False) == frozenset({"S"})
     assert get_keys(trajectory) == frozenset({"S", "time"})
-    assert str(trajectory) == "State({'time': tensor([0., 1., 2.]), 'S': tensor([1., 2., 3.])})"
+    assert (
+        str(trajectory)
+        == "State({'time': tensor([0., 1., 2.]), 'S': tensor([1., 2., 3.])})"
+    )
 
 
 def test_append():
-    trajectory1 = State(time=torch.tensor([0.0, 1.0, 2.0]), S=torch.tensor([1.0, 2.0, 3.0]))
-    trajectory2 = State(time=torch.tensor([3.0, 4.0, 5.0]), S=torch.tensor([4.0, 5.0, 6.0]))
+    trajectory1 = State(
+        time=torch.tensor([0.0, 1.0, 2.0]), S=torch.tensor([1.0, 2.0, 3.0])
+    )
+    trajectory2 = State(
+        time=torch.tensor([3.0, 4.0, 5.0]), S=torch.tensor([4.0, 5.0, 6.0])
+    )
     trajectory = append(trajectory1, trajectory2)
     assert torch.allclose(
         trajectory.S, torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])

--- a/tests/dynamical/test_log_trajectory.py
+++ b/tests/dynamical/test_log_trajectory.py
@@ -15,8 +15,7 @@ pyro.settings.set(module_local_params=True)
 logger = logging.getLogger(__name__)
 
 # Global variables for tests
-init_state = State(S=torch.tensor(1.0), I=torch.tensor(2.0), R=torch.tensor(3.3))
-start_time = torch.tensor(0.0)
+init_state = State(time=torch.tensor(0.0), S=torch.tensor(1.0), I=torch.tensor(2.0), R=torch.tensor(3.3))
 end_time = torch.tensor(4.0)
 logging_times = torch.tensor([1.0, 2.0, 3.0])
 
@@ -26,22 +25,22 @@ def test_logging():
     with LogTrajectory(
         times=logging_times,
     ) as dt1:
-        result1 = simulate(sir, init_state, start_time, end_time, solver=TorchDiffEq())
+        result1 = simulate(sir, init_state, end_time, solver=TorchDiffEq())
 
     with LogTrajectory(
         times=logging_times,
     ) as dt2:
         with InterruptionEventLoop():
             result2 = simulate(
-                sir, init_state, start_time, end_time, solver=TorchDiffEq()
+                sir, init_state, end_time, solver=TorchDiffEq()
             )
-    result3 = simulate(sir, init_state, start_time, end_time, solver=TorchDiffEq())
+    result3 = simulate(sir, init_state, end_time, solver=TorchDiffEq())
 
     assert isinstance(result1, State)
     assert isinstance(dt1.trajectory, State)
     assert isinstance(dt2.trajectory, State)
-    assert len(get_keys(dt1.trajectory)) == 3
-    assert len(get_keys(dt2.trajectory)) == 3
+    assert len(get_keys(dt1.trajectory)) == 4
+    assert len(get_keys(dt2.trajectory)) == 4
     assert get_keys(dt1.trajectory) == get_keys(result1)
     assert get_keys(dt2.trajectory) == get_keys(result2)
     assert check_states_match(result1, result2)

--- a/tests/dynamical/test_log_trajectory.py
+++ b/tests/dynamical/test_log_trajectory.py
@@ -51,15 +51,19 @@ def test_logging():
 
 
 def test_trajectory_methods():
-    trajectory = State(S=torch.tensor([1.0, 2.0, 3.0]))
-    assert get_keys(trajectory) == frozenset({"S"})
-    assert str(trajectory) == "State({'S': tensor([1., 2., 3.])})"
+    trajectory = State(time=torch.tensor([0.0, 1.0, 2.0]), S=torch.tensor([1.0, 2.0, 3.0]))
+    assert get_keys(trajectory, include_time=False) == frozenset({"S"})
+    assert get_keys(trajectory) == frozenset({"S", "time"})
+    assert str(trajectory) == "State({'time': tensor([0., 1., 2.]), 'S': tensor([1., 2., 3.])})"
 
 
 def test_append():
-    trajectory1 = State(S=torch.tensor([1.0, 2.0, 3.0]))
-    trajectory2 = State(S=torch.tensor([4.0, 5.0, 6.0]))
+    trajectory1 = State(time=torch.tensor([0.0, 1.0, 2.0]), S=torch.tensor([1.0, 2.0, 3.0]))
+    trajectory2 = State(time=torch.tensor([3.0, 4.0, 5.0]), S=torch.tensor([4.0, 5.0, 6.0]))
     trajectory = append(trajectory1, trajectory2)
     assert torch.allclose(
         trajectory.S, torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    ), "append() failed to append a trajectory"
+    assert torch.allclose(
+        trajectory.time, torch.tensor([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
     ), "append() failed to append a trajectory"

--- a/tests/dynamical/test_noop_interruptions.py
+++ b/tests/dynamical/test_noop_interruptions.py
@@ -17,11 +17,10 @@ from .dynamical_fixtures import UnifiedFixtureDynamics, check_states_match
 logger = logging.getLogger(__name__)
 
 # Points at which to measure the state of the system.
-start_time = torch.tensor(1.0)
 end_time = torch.tensor(4.0)
 # Initial state of the system.
 init_state_values = State(
-    S=torch.tensor(10.0), I=torch.tensor(3.0), R=torch.tensor(1.0)
+    time=torch.tensor(1.0), S=torch.tensor(10.0), I=torch.tensor(3.0), R=torch.tensor(1.0)
 )
 
 eps = 1e-3
@@ -36,18 +35,17 @@ intervene_states = [
 
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
 @pytest.mark.parametrize("init_state", [init_state_values])
-@pytest.mark.parametrize("start_time", [start_time])
 @pytest.mark.parametrize("end_time", [end_time])
-def test_noop_point_interruptions(model, init_state, start_time, end_time):
+def test_noop_point_interruptions(model, init_state, end_time):
     observational_execution_result = simulate(
-        model, init_state, start_time, end_time, solver=TorchDiffEq()
+        model, init_state, end_time, solver=TorchDiffEq()
     )
 
     # Test with standard point interruptions within timespan.
     with InterruptionEventLoop():
         with StaticInterruption(time=end_time / 2.0 + eps):
             result_pint = simulate(
-                model, init_state, start_time, end_time, solver=TorchDiffEq()
+                model, init_state, end_time, solver=TorchDiffEq()
             )
 
     assert check_states_match(observational_execution_result, result_pint)
@@ -59,7 +57,7 @@ def test_noop_point_interruptions(model, init_state, start_time, end_time):
         ):  # roughly 1/4 of the way through the timespan
             with StaticInterruption(time=(end_time / 4.0) * 3 + eps):  # roughly 3/4
                 result_double_pint1 = simulate(
-                    model, init_state, start_time, end_time, solver=TorchDiffEq()
+                    model, init_state, end_time, solver=TorchDiffEq()
                 )
 
     assert check_states_match(observational_execution_result, result_double_pint1)
@@ -69,7 +67,7 @@ def test_noop_point_interruptions(model, init_state, start_time, end_time):
         with StaticInterruption(time=(end_time / 4.0) * 3 + eps):  # roughly 3/4
             with StaticInterruption(time=end_time / 4.0 + eps):  # roughly 1/3
                 result_double_pint2 = simulate(
-                    model, init_state, start_time, end_time, solver=TorchDiffEq()
+                    model, init_state, end_time, solver=TorchDiffEq()
                 )
 
     assert check_states_match(observational_execution_result, result_double_pint2)
@@ -79,11 +77,10 @@ def test_noop_point_interruptions(model, init_state, start_time, end_time):
 
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
 @pytest.mark.parametrize("init_state", [init_state_values])
-@pytest.mark.parametrize("start_time", [start_time])
 @pytest.mark.parametrize("end_time", [end_time])
 @pytest.mark.parametrize("intervene_state", intervene_states)
 def test_noop_point_interventions(
-    model, init_state, start_time, end_time, intervene_state
+    model, init_state, end_time, intervene_state
 ):
     """
     Test whether point interruptions that don't intervene match the unhandled ("observatonal") default simulation.
@@ -93,7 +90,7 @@ def test_noop_point_interventions(
     post_measurement_intervention_time = end_time + 1.0
 
     observational_execution_result = simulate(
-        model, init_state, start_time, end_time, solver=TorchDiffEq()
+        model, init_state, end_time, solver=TorchDiffEq()
     )
 
     # Test a single point intervention.
@@ -105,7 +102,7 @@ def test_noop_point_interventions(
                 time=post_measurement_intervention_time, intervention=intervene_state
             ):
                 result_single_pi = simulate(
-                    model, init_state, start_time, end_time, solver=TorchDiffEq()
+                    model, init_state, end_time, solver=TorchDiffEq()
                 )
 
     assert check_states_match(observational_execution_result, result_single_pi)
@@ -123,7 +120,7 @@ def test_noop_point_interventions(
                     intervention=intervene_state,
                 ):
                     result_double_pi1 = simulate(
-                        model, init_state, start_time, end_time, solver=TorchDiffEq()
+                        model, init_state, end_time, solver=TorchDiffEq()
                     )
 
     assert check_states_match(observational_execution_result, result_double_pi1)
@@ -142,7 +139,7 @@ def test_noop_point_interventions(
                     intervention=intervene_state,
                 ):
                     result_double_pi2 = simulate(
-                        model, init_state, start_time, end_time, solver=TorchDiffEq()
+                        model, init_state, end_time, solver=TorchDiffEq()
                     )
 
     assert check_states_match(observational_execution_result, result_double_pi2)
@@ -150,17 +147,16 @@ def test_noop_point_interventions(
 
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
 @pytest.mark.parametrize("init_state", [init_state_values])
-@pytest.mark.parametrize("start_time", [start_time])
 @pytest.mark.parametrize("end_time", [end_time])
-def test_point_interruption_at_start(model, init_state, start_time, end_time):
+def test_point_interruption_at_start(model, init_state, end_time):
     observational_execution_result = simulate(
-        model, init_state, start_time, end_time, solver=TorchDiffEq()
+        model, init_state, end_time, solver=TorchDiffEq()
     )
 
     with InterruptionEventLoop():
         with StaticInterruption(time=1.0):
             result_pint = simulate(
-                model, init_state, start_time, end_time, solver=TorchDiffEq()
+                model, init_state, end_time, solver=TorchDiffEq()
             )
 
     assert check_states_match(observational_execution_result, result_pint)
@@ -168,23 +164,22 @@ def test_point_interruption_at_start(model, init_state, start_time, end_time):
 
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
 @pytest.mark.parametrize("init_state", [init_state_values])
-@pytest.mark.parametrize("start_time", [start_time])
 @pytest.mark.parametrize("end_time", [end_time])
 @pytest.mark.parametrize("intervene_state", intervene_states)
 def test_noop_dynamic_interruption(
-    model, init_state, start_time, end_time, intervene_state
+    model, init_state, end_time, intervene_state
 ):
     observational_execution_result = simulate(
-        model, init_state, start_time, end_time, solver=TorchDiffEq()
+        model, init_state, end_time, solver=TorchDiffEq()
     )
 
     with InterruptionEventLoop():
-        tt = (end_time - start_time) / 2.0
+        tt = (end_time - init_state.time) / 2.0
         with DynamicInterruption(
             event_f=lambda t, _: torch.where(t < tt, tt - t, 0.0),
         ):
             result_dint = simulate(
-                model, init_state, start_time, end_time, solver=TorchDiffEq()
+                model, init_state, end_time, solver=TorchDiffEq()
             )
 
     assert check_states_match(observational_execution_result, result_dint)

--- a/tests/dynamical/test_noop_interruptions.py
+++ b/tests/dynamical/test_noop_interruptions.py
@@ -20,7 +20,10 @@ logger = logging.getLogger(__name__)
 end_time = torch.tensor(4.0)
 # Initial state of the system.
 init_state_values = State(
-    time=torch.tensor(1.0), S=torch.tensor(10.0), I=torch.tensor(3.0), R=torch.tensor(1.0)
+    time=torch.tensor(1.0),
+    S=torch.tensor(10.0),
+    I=torch.tensor(3.0),
+    R=torch.tensor(1.0),
 )
 
 eps = 1e-3
@@ -44,9 +47,7 @@ def test_noop_point_interruptions(model, init_state, end_time):
     # Test with standard point interruptions within timespan.
     with InterruptionEventLoop():
         with StaticInterruption(time=end_time / 2.0 + eps):
-            result_pint = simulate(
-                model, init_state, end_time, solver=TorchDiffEq()
-            )
+            result_pint = simulate(model, init_state, end_time, solver=TorchDiffEq())
 
     assert check_states_match(observational_execution_result, result_pint)
 
@@ -79,9 +80,7 @@ def test_noop_point_interruptions(model, init_state, end_time):
 @pytest.mark.parametrize("init_state", [init_state_values])
 @pytest.mark.parametrize("end_time", [end_time])
 @pytest.mark.parametrize("intervene_state", intervene_states)
-def test_noop_point_interventions(
-    model, init_state, end_time, intervene_state
-):
+def test_noop_point_interventions(model, init_state, end_time, intervene_state):
     """
     Test whether point interruptions that don't intervene match the unhandled ("observatonal") default simulation.
     :return:
@@ -155,9 +154,7 @@ def test_point_interruption_at_start(model, init_state, end_time):
 
     with InterruptionEventLoop():
         with StaticInterruption(time=1.0):
-            result_pint = simulate(
-                model, init_state, end_time, solver=TorchDiffEq()
-            )
+            result_pint = simulate(model, init_state, end_time, solver=TorchDiffEq())
 
     assert check_states_match(observational_execution_result, result_pint)
 
@@ -166,9 +163,7 @@ def test_point_interruption_at_start(model, init_state, end_time):
 @pytest.mark.parametrize("init_state", [init_state_values])
 @pytest.mark.parametrize("end_time", [end_time])
 @pytest.mark.parametrize("intervene_state", intervene_states)
-def test_noop_dynamic_interruption(
-    model, init_state, end_time, intervene_state
-):
+def test_noop_dynamic_interruption(model, init_state, end_time, intervene_state):
     observational_execution_result = simulate(
         model, init_state, end_time, solver=TorchDiffEq()
     )
@@ -178,8 +173,6 @@ def test_noop_dynamic_interruption(
         with DynamicInterruption(
             event_f=lambda t, _: torch.where(t < tt, tt - t, 0.0),
         ):
-            result_dint = simulate(
-                model, init_state, end_time, solver=TorchDiffEq()
-            )
+            result_dint = simulate(model, init_state, end_time, solver=TorchDiffEq())
 
     assert check_states_match(observational_execution_result, result_dint)

--- a/tests/dynamical/test_solver.py
+++ b/tests/dynamical/test_solver.py
@@ -15,28 +15,32 @@ pyro.settings.set(module_local_params=True)
 logger = logging.getLogger(__name__)
 
 # Global variables for tests
-init_state = State(S=torch.tensor(1.0), I=torch.tensor(2.0), R=torch.tensor(3.3))
-start_time = torch.tensor(0.0)
+init_state = State(
+    time=torch.tensor(0.0),
+    S=torch.tensor(1.0),
+    I=torch.tensor(2.0),
+    R=torch.tensor(3.3),
+)
 end_time = torch.tensor(4.0)
 
 
 def test_no_backend_error():
     sir = bayes_sir_model()
     with pytest.raises(ValueError):
-        simulate(sir, init_state, start_time, end_time)
+        simulate(sir, init_state, end_time)
 
 
 def test_no_backend_SEL_error():
     sir = bayes_sir_model()
     with pytest.raises(ValueError):
         with InterruptionEventLoop():
-            simulate(sir, init_state, start_time, end_time)
+            simulate(sir, init_state, end_time)
 
 
 def test_backend_arg():
     sir = bayes_sir_model()
     with InterruptionEventLoop():
-        result = simulate(sir, init_state, start_time, end_time, solver=TorchDiffEq())
+        result = simulate(sir, init_state, end_time, solver=TorchDiffEq())
     assert result is not None
 
 
@@ -44,10 +48,8 @@ def test_backend_handler():
     sir = bayes_sir_model()
     with InterruptionEventLoop():
         with TorchDiffEq():
-            result_handler = simulate(sir, init_state, start_time, end_time)
+            result_handler = simulate(sir, init_state, end_time)
 
-        result_arg = simulate(
-            sir, init_state, start_time, end_time, solver=TorchDiffEq()
-        )
+        result_arg = simulate(sir, init_state, end_time, solver=TorchDiffEq())
 
     assert check_states_match(result_handler, result_arg)

--- a/tests/dynamical/test_static_interventions.py
+++ b/tests/dynamical/test_static_interventions.py
@@ -86,9 +86,7 @@ def test_point_intervention_causes_difference(
                         )
                     return
                 else:
-                    simulate(
-                        model, init_state, end_time, solver=TorchDiffEq()
-                    )
+                    simulate(model, init_state, end_time, solver=TorchDiffEq())
 
     observational_trajectory = observational_dt.trajectory
     intervened_trajectory = intervened_dt.trajectory
@@ -174,7 +172,6 @@ def test_nested_point_interventions_cause_difference(
                             simulate(
                                 model,
                                 init_state,
-                        
                                 end_time,
                                 solver=TorchDiffEq(),
                             )
@@ -192,7 +189,6 @@ def test_nested_point_interventions_cause_difference(
                         simulate(
                             model,
                             init_state,
-                    
                             end_time,
                             solver=TorchDiffEq(),
                         )
@@ -261,7 +257,6 @@ def test_multiworld_point_intervention(
                         cf_state = simulate(
                             model,
                             init_state,
-                    
                             end_time,
                             solver=TorchDiffEq(),
                         )
@@ -324,9 +319,7 @@ def test_twinworld_matches_output(
                 )
 
     with InterruptionEventLoop():
-        factual_expected = simulate(
-            model, init_state, end_time, solver=TorchDiffEq()
-        )
+        factual_expected = simulate(model, init_state, end_time, solver=TorchDiffEq())
 
     with cf:
         factual_indices = IndexSet(


### PR DESCRIPTION
Resolves #333 

This refactoring PR modifies `State` to include an optional `time` argument which is used for both (i) specifying time-dependent differential equation functions and (ii) instantiating `simulate` runs. This encapsulation removes the need for `start_time` from the `simulate` operation, and all subsequent internal `simulate`-like functions.