### PR TITLE
Remove stale skipped dynamical systems tests

### DIFF
--- a/tests/dynamical/test_dynamic_interventions.py
+++ b/tests/dynamical/test_dynamic_interventions.py
@@ -439,32 +439,6 @@ def test_grad_of_dynamic_intervention_event_f_params():
     assert torch.isclose(dzdparam, tt(-1.0), atol=1e-5)
 
 
-@pytest.mark.skip(reason="TODO")
-def test_grad_of_point_intervention_params():
-    # TODO This, somewhat unsurprisingly, does not work with point interventions,
-    #  presumably because its treated as two completely separate simulations.
-    # Note: implementing this would require the boilerplate from the dynamic test above.
-
-    # point_intervention = StaticIntervention(
-    #     intervention=State(dz=tt(1.0)),
-    #     time=param
-    # )
-    #
-    # # noinspection DuplicatedCode
-    # with InterruptionEventLoop():
-    #     with point_intervention:
-    #         traj = simulate(model, initial_state=s0, timespan=torch.tensor([0.0, 10.0]))
-    #
-    # dxdparam, = torch.autograd.grad(outputs=(traj.x[-1],), inputs=(param,), create_graph=True)
-    # assert torch.isclose(dxdparam, tt(0.0), atol=1e-5)
-    #
-    # # Z begins accruing dz=1 at t=param, so dzdparam should be -1.0.
-    # dzdparam, = torch.autograd.grad(outputs=(traj.z[-1],), inputs=(param,), create_graph=True)
-    # assert torch.isclose(dzdparam, tt(-1.0), atol=1e-5)
-
-    raise NotImplementedError()
-
-
 def test_grad_of_event_f_params_torchdiffeq_only():
     # This tests functionality tests in test_grad_of_dynamic_intervention_event_f_params
     # See "NOTE: parameters for the event function must be in the state itself to obtain gradients."

--- a/tests/dynamical/test_handler_composition.py
+++ b/tests/dynamical/test_handler_composition.py
@@ -131,8 +131,3 @@ def test_smoke_inference_twincounterfactual_observation_intervention_commutes():
     )
     # Noise is shared between factual and counterfactual worlds.
     assert pred["u_ip"].squeeze().shape == (num_samples, len(flight_landing_times))
-
-
-@pytest.mark.skip
-def test_shape_multicounterfactual_observation_intervention_commutes():
-    raise NotImplementedError()

--- a/tests/dynamical/test_handler_composition.py
+++ b/tests/dynamical/test_handler_composition.py
@@ -1,7 +1,6 @@
 import logging
 
 import pyro
-import pytest
 import torch
 from pyro.distributions import Normal
 

--- a/tests/dynamical/test_static_observation.py
+++ b/tests/dynamical/test_static_observation.py
@@ -189,28 +189,6 @@ def test_interrupting_and_non_interrupting_observation_array_equivalence(model):
     assert torch.isclose(tr1.trace.log_prob_sum(), tr2.trace.log_prob_sum())
 
 
-@pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
-@pytest.mark.parametrize("init_state", [init_state])
-@pytest.mark.parametrize("start_time", [start_time])
-@pytest.mark.parametrize("end_time", [end_time])
-@pytest.mark.skip(
-    "The error that this test was written for has been fixed. Leaving for posterity."
-)
-def test_point_observation_at_tspan_start_excepts(
-    model, init_state, start_time, end_time
-):
-    """
-    This test requires that we raise an explicit exception when a StaticObservation
-    occurs at the beginning of the tspan.
-    This occurs right now due to an undiagnosed error, so this test is a stand-in until that can be fixed.
-    """
-
-    with InterruptionEventLoop():
-        with pytest.raises(ValueError, match="occurred at the start of the timespan"):
-            with StaticObservation(time=start_time, data={"S_obs": torch.tensor(10.0)}):
-                simulate(model, init_state, start_time, end_time, solver=TorchDiffEq())
-
-
 @pytest.mark.parametrize("model", [bayes_sir_model])
 def test_svi_composition_test_multi_point_obs(model):
     data1 = {


### PR DESCRIPTION
This refactoring PR removes unit tests that were being skipped.