### PR TITLE
Use observe operation in dynamical system observation handlers

### DIFF
--- a/chirho/dynamical/internals/_utils.py
+++ b/chirho/dynamical/internals/_utils.py
@@ -103,7 +103,7 @@ def _observe_state(
     if obs is rv or obs is None:
         return rv
 
-    return type(rv)(
+    return State(
         **{
             k: observe(getattr(rv, k), getattr(obs, k), name=f"{name}__{k}", **kwargs)
             for k in get_keys(rv)

--- a/chirho/dynamical/internals/_utils.py
+++ b/chirho/dynamical/internals/_utils.py
@@ -1,11 +1,13 @@
+import collections.abc
 import functools
-from typing import FrozenSet, Tuple, TypeVar
+from typing import FrozenSet, Optional, Tuple, TypeVar
 
 import torch
 
 from chirho.dynamical.ops import State, get_keys
 from chirho.indexed.ops import IndexSet, gather, indices_of, union
 from chirho.interventional.handlers import intervene
+from chirho.observational.ops import Observation, observe
 
 S = TypeVar("S")
 T = TypeVar("T")
@@ -84,3 +86,26 @@ def _var_order(varnames: FrozenSet[str]) -> Tuple[str, ...]:
 
 def _squeeze_time_dim(traj: State[T]) -> State[T]:
     return State(**{k: getattr(traj, k).squeeze(-1) for k in get_keys(traj)})
+
+
+@observe.register(State)
+def _observe_state(
+    rv: State[T],
+    obs: Optional[Observation[State[T]]] = None,
+    *,
+    name: Optional[str] = None,
+    **kwargs
+) -> State[T]:
+
+    if isinstance(obs, collections.abc.Callable):
+        obs = obs(rv)
+        if obs is not rv and obs is not None:
+            raise NotImplementedError("Dependent observations are not yet supported")
+
+    if obs is rv or obs is None:
+        return rv
+
+    return type(rv)(**{
+        k: observe(getattr(rv, k), getattr(obs, k), name=f"{name}__{k}", **kwargs)
+        for k in get_keys(rv)
+    })

--- a/chirho/dynamical/internals/_utils.py
+++ b/chirho/dynamical/internals/_utils.py
@@ -1,4 +1,3 @@
-import collections.abc
 import functools
 from typing import FrozenSet, Optional, Tuple, TypeVar
 
@@ -94,10 +93,9 @@ def _observe_state(
     obs: Optional[Observation[State[T]]] = None,
     *,
     name: Optional[str] = None,
-    **kwargs
+    **kwargs,
 ) -> State[T]:
-
-    if isinstance(obs, collections.abc.Callable):
+    if callable(obs):
         obs = obs(rv)
         if obs is not rv and obs is not None:
             raise NotImplementedError("Dependent observations are not yet supported")
@@ -105,7 +103,9 @@ def _observe_state(
     if obs is rv or obs is None:
         return rv
 
-    return type(rv)(**{
-        k: observe(getattr(rv, k), getattr(obs, k), name=f"{name}__{k}", **kwargs)
-        for k in get_keys(rv)
-    })
+    return type(rv)(
+        **{
+            k: observe(getattr(rv, k), getattr(obs, k), name=f"{name}__{k}", **kwargs)
+            for k in get_keys(rv)
+        }
+    )

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -37,12 +37,6 @@ def get_keys(state: State[T]) -> FrozenSet[str]:
 
 
 @typing.runtime_checkable
-class Observable(Protocol[S]):
-    def observation(self, __state: State[S]) -> None:
-        ...
-
-
-@typing.runtime_checkable
 class InPlaceDynamics(Protocol[S]):
     def diff(self, __dstate: State[S], __state: State[S]) -> None:
         ...

--- a/tests/dynamical/dynamical_fixtures.py
+++ b/tests/dynamical/dynamical_fixtures.py
@@ -37,11 +37,9 @@ class UnifiedFixtureDynamics:
             return pyro.sample(name, Normal(x, 1).to_event(1))
 
     def observation(self, X: State[torch.Tensor]):
-        S_obs = self._unit_measurement_error("S_obs", X.S)
-        I_obs = self._unit_measurement_error("I_obs", X.I)
-        R_obs = self._unit_measurement_error("R_obs", X.R)
-
-        return {"S_obs": S_obs, "I_obs": I_obs, "R_obs": R_obs}
+        self._unit_measurement_error("S_obs", X.S)
+        self._unit_measurement_error("I_obs", X.I)
+        self._unit_measurement_error("R_obs", X.R)
 
 
 def bayes_sir_model():

--- a/tests/dynamical/test_handler_composition.py
+++ b/tests/dynamical/test_handler_composition.py
@@ -134,3 +134,8 @@ def test_smoke_inference_twincounterfactual_observation_intervention_commutes():
     )
     # Noise is shared between factual and counterfactual worlds.
     assert pred["u_ip"].squeeze().shape == (num_samples, len(flight_landing_times))
+
+
+@pytest.mark.skip
+def test_shape_multicounterfactual_observation_intervention_commutes():
+    raise NotImplementedError()

--- a/tests/dynamical/test_handler_composition.py
+++ b/tests/dynamical/test_handler_composition.py
@@ -14,6 +14,7 @@ from chirho.dynamical.handlers import (
 )
 from chirho.dynamical.handlers.solver import TorchDiffEq
 from chirho.dynamical.ops import State, simulate
+from chirho.observational.handlers import condition
 from chirho.observational.handlers.soft_conditioning import AutoSoftConditioning
 from tests.dynamical.dynamical_fixtures import (
     UnifiedFixtureDynamics,
@@ -56,15 +57,17 @@ reparam_config = AutoSoftConditioning(scale=0.01, alpha=0.5)
 twin_world = TwinWorldCounterfactual()
 intervention = StaticIntervention(time=superspreader_time, intervention=counterfactual)
 reparam = pyro.poutine.reparam(config=reparam_config)
-vec_obs3 = StaticBatchObservation(times=flight_landing_times, data=flight_landing_data)
 
 
 def counterf_model():
+    model = UnifiedFixtureDynamicsReparam(beta=0.5, gamma=0.7)
+    obs = condition(data=flight_landing_data)(model.observation)
+    vec_obs3 = StaticBatchObservation(times=flight_landing_times, observation=obs)
     with vec_obs3:
         with InterruptionEventLoop():
             with reparam, twin_world, intervention:
                 return simulate(
-                    UnifiedFixtureDynamicsReparam(beta=0.5, gamma=0.7),
+                    model,
                     init_state,
                     start_time,
                     end_time,
@@ -131,8 +134,3 @@ def test_smoke_inference_twincounterfactual_observation_intervention_commutes():
     )
     # Noise is shared between factual and counterfactual worlds.
     assert pred["u_ip"].squeeze().shape == (num_samples, len(flight_landing_times))
-
-
-@pytest.mark.skip
-def test_shape_multicounterfactual_observation_intervention_commutes():
-    raise NotImplementedError()

--- a/tests/dynamical/test_static_observation.py
+++ b/tests/dynamical/test_static_observation.py
@@ -179,15 +179,9 @@ def test_interrupting_and_non_interrupting_observation_array_equivalence(model):
 
     with pyro.poutine.trace() as tr1:
         with InterruptionEventLoop():
-            with StaticObservation(
-                time=times[1].item(), observation=obs1
-            ):
-                with StaticObservation(
-                    time=times[0].item(), observation=obs0
-                ):
-                    with StaticObservation(
-                        time=times[2].item(), observation=obs2
-                    ):
+            with StaticObservation(time=times[1].item(), observation=obs1):
+                with StaticObservation(time=times[0].item(), observation=obs0):
+                    with StaticObservation(time=times[2].item(), observation=obs2):
                         interrupting_ret = simulate(
                             model,
                             init_state,

--- a/tests/dynamical/test_static_observation.py
+++ b/tests/dynamical/test_static_observation.py
@@ -14,6 +14,7 @@ from chirho.dynamical.handlers import (
 )
 from chirho.dynamical.handlers.solver import TorchDiffEq
 from chirho.dynamical.ops import State, simulate
+from chirho.observational.handlers import condition
 
 from .dynamical_fixtures import (
     UnifiedFixtureDynamics,
@@ -57,12 +58,14 @@ def test_multiple_point_observations(model):
     S_obs = torch.tensor(10.0)
     data1 = {"S_obs": S_obs}
     data2 = {"I_obs": torch.tensor(5.0), "R_obs": torch.tensor(5.0)}
+    obs1 = condition(data=data1)(model.observation)
+    obs2 = condition(data=data2)(model.observation)
     with InterruptionEventLoop():
         result1 = simulate(
             model, init_state, start_time, end_time, solver=TorchDiffEq()
         )
-        with StaticObservation(time=3.1, data=data2):
-            with StaticObservation(time=2.9, data=data1):
+        with StaticObservation(time=3.1, observation=obs2):
+            with StaticObservation(time=2.9, observation=obs1):
                 result2 = simulate(
                     model, init_state, start_time, end_time, solver=TorchDiffEq()
                 )
@@ -70,49 +73,50 @@ def test_multiple_point_observations(model):
     check_states_match(result1, result2)
 
 
-def _get_compatible_observations(obs_handler, time, data):
-    """
-    Returns a list of compatible observations for the given observation handler.
-    """
-    # AZ - Not using dispatcher here b/c obs_handler is a class not an instance of a class.
-    if obs_handler is StaticObservation:
-        return StaticObservation(time=time, data=data)
-    elif obs_handler is StaticBatchObservation:
-        # Just make make a two element observation array.
-        return StaticBatchObservation(
-            times=torch.tensor([time, time + 0.1]),
-            data={k: torch.tensor([v, v]) for k, v in data.items()},
-        )
-
-
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
-@pytest.mark.parametrize("obs_handler", [StaticObservation, StaticBatchObservation])
-def test_log_prob_exists(model, obs_handler):
+@pytest.mark.parametrize("obs_handler_cls", [StaticObservation, StaticBatchObservation])
+def test_log_prob_exists(model, obs_handler_cls):
     """
     Tests if the log_prob exists at the observed site.
     """
     S_obs = torch.tensor(10.0)
     data = {"S_obs": S_obs}
+    time = 2.9
+    if obs_handler_cls is StaticObservation:
+        obs = condition(data=data)(model.observation)
+    else:
+        time = torch.tensor([time, time + 0.1])
+        data = {k: torch.tensor([v, v]) for k, v in data.items()}
+        obs = condition(data=data)(model.observation)
+
     with pyro.poutine.trace() as tr:
         with InterruptionEventLoop():
-            with _get_compatible_observations(obs_handler, time=2.9, data=data):
+            with obs_handler_cls(time, observation=obs):
                 simulate(model, init_state, start_time, end_time, solver=TorchDiffEq())
 
     assert isinstance(tr.trace.log_prob_sum(), torch.Tensor), "No log_prob found!"
 
 
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
-@pytest.mark.parametrize("obs_handler", [StaticObservation, StaticBatchObservation])
-def test_tspan_collision(model, obs_handler):
+@pytest.mark.parametrize("obs_handler_cls", [StaticObservation, StaticBatchObservation])
+def test_tspan_collision(model, obs_handler_cls):
     """
     Tests if observation times that intersect with tspan do not raise an error or create
     shape mismatches.
     """
     S_obs = torch.tensor(10.0)
     data = {"S_obs": S_obs}
+    time = start_time
+    if obs_handler_cls is StaticObservation:
+        obs = condition(data=data)(model.observation)
+    else:
+        data = {k: torch.tensor([v, v]) for k, v in data.items()}
+        obs = condition(data=data)(model.observation)
+        time = torch.tensor([time, time + 0.1])
+
     with LogTrajectory(logging_times) as dt:
         with InterruptionEventLoop():
-            with _get_compatible_observations(obs_handler, time=start_time, data=data):
+            with obs_handler_cls(time, observation=obs):
                 simulate(model, init_state, start_time, end_time, solver=TorchDiffEq())
     result = dt.trajectory
     assert result.S.shape[0] == len(logging_times)
@@ -121,19 +125,29 @@ def test_tspan_collision(model, obs_handler):
 
 
 @pytest.mark.parametrize("model", [bayes_sir_model])
-@pytest.mark.parametrize("obs_handler", [StaticObservation, StaticBatchObservation])
-def test_svi_composition_test_one(model, obs_handler):
-    data1 = {
+@pytest.mark.parametrize("obs_handler_cls", [StaticObservation, StaticBatchObservation])
+def test_svi_composition_test_one(model, obs_handler_cls):
+    data = {
         "S_obs": torch.tensor(10.0),
         "I_obs": torch.tensor(5.0),
         "R_obs": torch.tensor(5.0),
     }
+    time = 2.9
 
     class ConditionedSIR(pyro.nn.PyroModule):
         def forward(self):
             sir = model()
+
+            if obs_handler_cls is StaticObservation:
+                obs = condition(data=data)(sir.observation)
+                time_ = time
+            else:
+                data_ = {k: torch.tensor([v, v]) for k, v in data.items()}
+                obs = condition(data=data_)(sir.observation)
+                time_ = torch.tensor([time, time + 0.1])
+
             with InterruptionEventLoop():
-                with _get_compatible_observations(obs_handler, time=2.9, data=data1):
+                with obs_handler_cls(time_, observation=obs):
                     traj = simulate(
                         sir, init_state, start_time, end_time, solver=TorchDiffEq()
                     )
@@ -158,16 +172,21 @@ def test_interrupting_and_non_interrupting_observation_array_equivalence(model):
     )
     times = torch.tensor([1.5, 2.9, 3.2])
 
+    obs = condition(data=data)(model.observation)
+    obs0 = condition(data={k: v[0] for k, v in data.items()})(model.observation)
+    obs1 = condition(data={k: v[1] for k, v in data.items()})(model.observation)
+    obs2 = condition(data={k: v[2] for k, v in data.items()})(model.observation)
+
     with pyro.poutine.trace() as tr1:
         with InterruptionEventLoop():
             with StaticObservation(
-                time=times[1].item(), data={k: v[1] for k, v in data.items()}
+                time=times[1].item(), observation=obs1
             ):
                 with StaticObservation(
-                    time=times[0].item(), data={k: v[0] for k, v in data.items()}
+                    time=times[0].item(), observation=obs0
                 ):
                     with StaticObservation(
-                        time=times[2].item(), data={k: v[2] for k, v in data.items()}
+                        time=times[2].item(), observation=obs2
                     ):
                         interrupting_ret = simulate(
                             model,
@@ -179,7 +198,7 @@ def test_interrupting_and_non_interrupting_observation_array_equivalence(model):
 
     with pyro.poutine.trace() as tr2:
         with InterruptionEventLoop():
-            with StaticBatchObservation(times=times, data=data):
+            with StaticBatchObservation(times=times, observation=obs):
                 non_interrupting_ret = simulate(
                     model, init_state, start_time, end_time, solver=TorchDiffEq()
                 )
@@ -187,28 +206,6 @@ def test_interrupting_and_non_interrupting_observation_array_equivalence(model):
     assert check_states_match(interrupting_ret, non_interrupting_ret)
 
     assert torch.isclose(tr1.trace.log_prob_sum(), tr2.trace.log_prob_sum())
-
-
-@pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
-@pytest.mark.parametrize("init_state", [init_state])
-@pytest.mark.parametrize("start_time", [start_time])
-@pytest.mark.parametrize("end_time", [end_time])
-@pytest.mark.skip(
-    "The error that this test was written for has been fixed. Leaving for posterity."
-)
-def test_point_observation_at_tspan_start_excepts(
-    model, init_state, start_time, end_time
-):
-    """
-    This test requires that we raise an explicit exception when a StaticObservation
-    occurs at the beginning of the tspan.
-    This occurs right now due to an undiagnosed error, so this test is a stand-in until that can be fixed.
-    """
-
-    with InterruptionEventLoop():
-        with pytest.raises(ValueError, match="occurred at the start of the timespan"):
-            with StaticObservation(time=start_time, data={"S_obs": torch.tensor(10.0)}):
-                simulate(model, init_state, start_time, end_time, solver=TorchDiffEq())
 
 
 @pytest.mark.parametrize("model", [bayes_sir_model])
@@ -235,7 +232,8 @@ def test_svi_composition_test_multi_point_obs(model):
             for obs in data.values():
                 obs_time = obs[0].item()
                 obs_data = obs[1]
-                observation_managers.append(StaticObservation(obs_time, obs_data))
+                obs_model = condition(data=obs_data)(sir.observation)
+                observation_managers.append(StaticObservation(obs_time, obs_model))
             with InterruptionEventLoop():
                 with ExitStack() as stack:
                     for manager in observation_managers:
@@ -264,8 +262,9 @@ def test_svi_composition_vectorized_obs(model):
     class ConditionedSIR(pyro.nn.PyroModule):
         def forward(self):
             sir = model()
+            obs = condition(data=data)(sir.observation)
             with InterruptionEventLoop():
-                with StaticBatchObservation(times=times, data=data):
+                with StaticBatchObservation(times=times, observation=obs):
                     traj = simulate(
                         sir, init_state, start_time, end_time, solver=TorchDiffEq()
                     )
@@ -298,9 +297,11 @@ def test_simulate_persistent_pyrosample(use_event_loop):
             S_obs = torch.tensor(10.0)
             data1 = {"S_obs": S_obs}
             data2 = {"I_obs": torch.tensor(5.0), "R_obs": torch.tensor(5.0)}
+            obs1 = condition(data=data1)(model.observation)
+            obs2 = condition(data=data2)(model.observation)
             with InterruptionEventLoop():
-                with StaticObservation(time=3.1, data=data2):
-                    with StaticObservation(time=2.9, data=data1):
+                with StaticObservation(time=3.1, observation=obs2):
+                    with StaticObservation(time=2.9, observation=obs1):
                         simulate(
                             model,
                             init_state,

--- a/tests/dynamical/test_static_observation.py
+++ b/tests/dynamical/test_static_observation.py
@@ -208,6 +208,28 @@ def test_interrupting_and_non_interrupting_observation_array_equivalence(model):
     assert torch.isclose(tr1.trace.log_prob_sum(), tr2.trace.log_prob_sum())
 
 
+@pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
+@pytest.mark.parametrize("init_state", [init_state])
+@pytest.mark.parametrize("start_time", [start_time])
+@pytest.mark.parametrize("end_time", [end_time])
+@pytest.mark.skip(
+    "The error that this test was written for has been fixed. Leaving for posterity."
+)
+def test_point_observation_at_tspan_start_excepts(
+    model, init_state, start_time, end_time
+):
+    """
+    This test requires that we raise an explicit exception when a StaticObservation
+    occurs at the beginning of the tspan.
+    This occurs right now due to an undiagnosed error, so this test is a stand-in until that can be fixed.
+    """
+
+    with InterruptionEventLoop():
+        with pytest.raises(ValueError, match="occurred at the start of the timespan"):
+            with StaticObservation(time=start_time, data={"S_obs": torch.tensor(10.0)}):
+                simulate(model, init_state, start_time, end_time, solver=TorchDiffEq())
+
+
 @pytest.mark.parametrize("model", [bayes_sir_model])
 def test_svi_composition_test_multi_point_obs(model):
     data1 = {


### PR DESCRIPTION
Resolves #334 

This refactoring PR makes the handlers `chirho.dynamical.handlers.interruption.StaticObservation` and `chirho.dynamical.handlers.interruption.StaticBatchObservation` use the `chirho.observational.ops.observe` primitive directly, rather than assuming a model comes with a special `.observation` method.