### PR TITLE
Replace custom State type with Dict

### DIFF
--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -1,6 +1,6 @@
 import numbers
 import typing
-from typing import Callable, FrozenSet, Generic, Optional, TypeVar, Union
+from typing import Callable, Dict, FrozenSet, Generic, Optional, TypeVar, Union
 
 import pyro
 import torch
@@ -10,30 +10,12 @@ S = TypeVar("S")
 T = TypeVar("T")
 
 
-class State(Generic[T]):
-    def __init__(self, **values: T):
-        self.__dict__["_values"] = {}
-        for k, v in values.items():
-            setattr(self, k, v)
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.__dict__['_values']})"
-
-    def __str__(self) -> str:
-        return f"{self.__class__.__name__}({self.__dict__['_values']})"
-
-    def __setattr__(self, __name: str, __value: T) -> None:
-        self.__dict__["_values"][__name] = __value
-
-    def __getattr__(self, __name: str) -> T:
-        if __name in self.__dict__["_values"]:
-            return self.__dict__["_values"][__name]
-        else:
-            raise AttributeError(f"{__name} not in {self.__dict__['_values']}")
+class State(Generic[T], Dict[str, T]):
+    pass
 
 
 def get_keys(state: State[T]) -> FrozenSet[str]:
-    return frozenset(state.__dict__["_values"].keys())
+    return frozenset(state.keys())
 
 
 Dynamics = Callable[[State[T]], State[T]]

--- a/tests/dynamical/test_handler_composition.py
+++ b/tests/dynamical/test_handler_composition.py
@@ -94,8 +94,10 @@ class UnifiedFixtureDynamicsReparam(UnifiedFixtureDynamics):
 
         # A flight arrives in a country that tests all arrivals for a disease. The number of people infected on the
         #  plane is a noisy function of the number of infected people in the country of origin at that time.
-        u_ip = pyro.sample("u_ip", Normal(7.0, 2.0).expand(X.I.shape[-1:]).to_event(1))
-        pyro.deterministic("infected_passengers", X.I + u_ip, event_dim=1)
+        u_ip = pyro.sample(
+            "u_ip", Normal(7.0, 2.0).expand(X["I"].shape[-1:]).to_event(1)
+        )
+        pyro.deterministic("infected_passengers", X["I"] + u_ip, event_dim=1)
 
 
 def test_shape_twincounterfactual_observation_intervention_commutes():
@@ -108,9 +110,9 @@ def test_shape_twincounterfactual_observation_intervention_commutes():
     num_worlds = 2
 
     state_shape = (num_worlds, len(logging_times))
-    assert ret.S.squeeze().squeeze().shape == state_shape
-    assert ret.I.squeeze().squeeze().shape == state_shape
-    assert ret.R.squeeze().squeeze().shape == state_shape
+    assert ret["S"].squeeze().squeeze().shape == state_shape
+    assert ret["I"].squeeze().squeeze().shape == state_shape
+    assert ret["R"].squeeze().squeeze().shape == state_shape
 
     nodes = tr.get_trace().nodes
 

--- a/tests/dynamical/test_log_trajectory.py
+++ b/tests/dynamical/test_log_trajectory.py
@@ -51,7 +51,6 @@ def test_logging():
 def test_trajectory_methods():
     trajectory = State(S=torch.tensor([1.0, 2.0, 3.0]))
     assert get_keys(trajectory) == frozenset({"S"})
-    assert str(trajectory) == "State({'S': tensor([1., 2., 3.])})"
 
 
 def test_append():
@@ -59,5 +58,5 @@ def test_append():
     trajectory2 = State(S=torch.tensor([4.0, 5.0, 6.0]))
     trajectory = append(trajectory1, trajectory2)
     assert torch.allclose(
-        trajectory.S, torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        trajectory["S"], torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
     ), "append() failed to append a trajectory"

--- a/tests/dynamical/test_static_interventions.py
+++ b/tests/dynamical/test_static_interventions.py
@@ -243,8 +243,8 @@ def test_twinworld_point_intervention(
         cf_trajectory = dt.trajectory
         for k in get_keys(cf_trajectory):
             # TODO: Figure out why event_dim=1 is not needed with cf_state but is with cf_trajectory.
-            assert cf.default_name in indices_of(getattr(cf_state, k))
-            assert cf.default_name in indices_of(getattr(cf_trajectory, k), event_dim=1)
+            assert cf.default_name in indices_of(cf_state[k])
+            assert cf.default_name in indices_of(cf_trajectory[k], event_dim=1)
 
 
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
@@ -278,8 +278,8 @@ def test_multiworld_point_intervention(
         cf_trajectory = dt.trajectory
         for k in get_keys(cf_trajectory):
             # TODO: Figure out why event_dim=1 is not needed with cf_state but is with cf_trajectory.
-            assert cf.default_name in indices_of(getattr(cf_state, k))
-            assert cf.default_name in indices_of(getattr(cf_trajectory, k), event_dim=1)
+            assert cf.default_name in indices_of(cf_state[k])
+            assert cf.default_name in indices_of(cf_trajectory[k], event_dim=1)
 
 
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
@@ -301,7 +301,7 @@ def test_split_odeint_broadcast(
     with cf:
         trajectory = dt.trajectory
         for k in get_keys(trajectory):
-            assert len(indices_of(getattr(trajectory, k), event_dim=1)) > 0
+            assert len(indices_of(trajectory[k], event_dim=1)) > 0
 
 
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
@@ -358,10 +358,10 @@ def test_twinworld_matches_output(
 
     for k in get_keys(cf_state):
         assert torch.allclose(
-            getattr(cf_actual, k), getattr(cf_expected, k)
+            cf_actual[k], cf_expected[k]
         ), f"States differ in state trajectory of variable {k}, but should be identical."
 
     for k in get_keys(cf_state):
         assert torch.allclose(
-            getattr(factual_actual, k), getattr(factual_expected, k)
+            factual_actual[k], factual_expected[k]
         ), f"States differ in state trajectory of variable {k}, but should be identical."

--- a/tests/dynamical/test_static_observation.py
+++ b/tests/dynamical/test_static_observation.py
@@ -119,9 +119,9 @@ def test_tspan_collision(model, obs_handler_cls):
             with obs_handler_cls(time, observation=obs):
                 simulate(model, init_state, start_time, end_time, solver=TorchDiffEq())
     result = dt.trajectory
-    assert result.S.shape[0] == len(logging_times)
-    assert result.I.shape[0] == len(logging_times)
-    assert result.R.shape[0] == len(logging_times)
+    assert result["S"].shape[0] == len(logging_times)
+    assert result["I"].shape[0] == len(logging_times)
+    assert result["R"].shape[0] == len(logging_times)
 
 
 @pytest.mark.parametrize("model", [bayes_sir_model])
@@ -305,6 +305,6 @@ def test_simulate_persistent_pyrosample(use_event_loop):
                         )
     result = dt.trajectory
 
-    assert result.S.shape[0] == len(logging_times)
-    assert result.I.shape[0] == len(logging_times)
-    assert result.R.shape[0] == len(logging_times)
+    assert result["S"].shape[0] == len(logging_times)
+    assert result["I"].shape[0] == len(logging_times)
+    assert result["R"].shape[0] == len(logging_times)


### PR DESCRIPTION
As the title suggests, this small refactoring PR replaces the custom `State` type with a more generic `Dict`. Included in this PR is the replacement of all calls from `getattr` to `get` (or the corresponding dict indexing syntax) as well as small changes to types throughout.