### PR TITLE
Remove get_keys operation

### DIFF
--- a/chirho/dynamical/handlers/interruption.py
+++ b/chirho/dynamical/handlers/interruption.py
@@ -6,7 +6,7 @@ import pyro
 import torch
 
 from chirho.dynamical.handlers.trajectory import LogTrajectory
-from chirho.dynamical.ops import State, get_keys
+from chirho.dynamical.ops import State
 from chirho.indexed.ops import get_index_plates, indices_of
 from chirho.interventional.ops import Intervention, intervene
 from chirho.observational.ops import Observation, observe
@@ -169,7 +169,7 @@ class StaticBatchObservation(Generic[T], LogTrajectory[T]):
         name_to_dim["__time"] = -1
         len_traj = (
             0
-            if not get_keys(self.trajectory)
+            if len(self.trajectory.keys()) == 0
             else 1 + max(indices_of(self.trajectory, name_to_dim=name_to_dim)["__time"])
         )
 

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -1,6 +1,6 @@
 import numbers
 import typing
-from typing import Callable, Dict, FrozenSet, Generic, Optional, TypeVar, Union
+from typing import Callable, Dict, Generic, Optional, TypeVar, Union
 
 import pyro
 import torch
@@ -12,10 +12,6 @@ T = TypeVar("T")
 
 class State(Generic[T], Dict[str, T]):
     pass
-
-
-def get_keys(state: State[T]) -> FrozenSet[str]:
-    return frozenset(state.keys())
 
 
 Dynamics = Callable[[State[T]], State[T]]

--- a/docs/source/dynamical_intro.ipynb
+++ b/docs/source/dynamical_intro.ipynb
@@ -898,7 +898,7 @@
     "                    \n",
     "    trajectory = dt.trace\n",
     "    # This is a small trick to make the solution variables available to pyro\n",
-    "    [pyro.deterministic(k, getattr(trajectory, k)) for k in get_keys(trajectory)]\n",
+    "    [pyro.deterministic(k, getattr(trajectory, k)) for k in trajectory.keys()]\n",
     "    return trajectory"
    ]
   },

--- a/docs/source/dynamical_intro.ipynb
+++ b/docs/source/dynamical_intro.ipynb
@@ -44,7 +44,7 @@
     "    NonInterruptingPointObservationArray\n",
     ")\n",
     "from chirho.dynamical.handlers.interruption import _InterventionMixin\n",
-    "from chirho.dynamical.ops.dynamical import State, Trajectory, get_keys, simulate\n",
+    "from chirho.dynamical.ops.dynamical import State, Trajectory, simulate\n",
     "\n",
     "from chirho.dynamical.ops.ODE import ODEDynamics\n",
     "from chirho.dynamical.handlers.ODE.solvers import TorchDiffEq\n",
@@ -420,7 +420,7 @@
     "        simulate(sir, init_state, logging_times[0], logging_times[-1] + 1e-3, solver=TorchDiffEq())\n",
     "    trajectory = dt.trace\n",
     "    # This is a small trick to make the solution variables available to pyro\n",
-    "    [pyro.deterministic(k, getattr(trajectory, k)) for k in get_keys(trajectory)]\n",
+    "    [pyro.deterministic(k, getattr(trajectory, k)) for k in trajectory.keys()]\n",
     "    return trajectory\n",
     "\n",
     "\n",
@@ -1258,7 +1258,7 @@
     "    trajectory = dt.trace\n",
     "    \n",
     "    # This is a small trick to make the solution variables available to pyro\n",
-    "    [pyro.deterministic(k, getattr(trajectory, k)) for k in get_keys(trajectory)]\n",
+    "    [pyro.deterministic(k, getattr(trajectory, k)) for k in trajectory.keys()]\n",
     "    return trajectory"
    ]
   },
@@ -1747,7 +1747,7 @@
     "        cf_traj = gather(trajectory, cf_indices, event_dim=0)\n",
     "        \n",
     "        # This is a small trick to make the trajectory variables available to pyro    \n",
-    "        for k in get_keys(trajectory):\n",
+    "        for k in trajectory.keys():\n",
     "            pyro.deterministic(k + '_factual', getattr(factual_traj, k))\n",
     "            pyro.deterministic(k + '_cf', getattr(cf_traj, k))"
    ]
@@ -2185,7 +2185,7 @@
     "        trajectory = dt.trace\n",
     "        solutions.append(trajectory)\n",
     "        # This is a small trick to make the trajectory variables available to pyro\n",
-    "        [pyro.deterministic(f\"{k}_{unit_ix}\", getattr(trajectory, k))for k in get_keys(trajectory)]\n",
+    "        [pyro.deterministic(f\"{k}_{unit_ix}\", getattr(trajectory, k))for k in trajectory.keys()]\n",
     "    return solutions\n",
     "\n",
     "\n",

--- a/tests/dynamical/dynamical_fixtures.py
+++ b/tests/dynamical/dynamical_fixtures.py
@@ -4,7 +4,7 @@ import pyro
 import torch
 from pyro.distributions import Normal, Uniform, constraints
 
-from chirho.dynamical.ops import State, get_keys
+from chirho.dynamical.ops import State
 
 pyro.settings.set(module_local_params=True)
 
@@ -55,14 +55,14 @@ def bayes_sir_model():
 
 
 def check_keys_match(obj1: State[T], obj2: State[T]):
-    assert get_keys(obj1) == get_keys(obj2), "Objects have different variables."
+    assert set(obj1.keys()) == set(obj2.keys()), "Objects have different variables."
     return True
 
 
 def check_states_match(state1: State[torch.Tensor], state2: State[torch.Tensor]):
     assert check_keys_match(state1, state2)
 
-    for k in get_keys(state1):
+    for k in state1.keys():
         assert torch.allclose(
             state1[k], state2[k]
         ), f"Trajectories differ in state trajectory of variable {k}, but should be identical."
@@ -75,7 +75,7 @@ def check_trajectories_match_in_all_but_values(
 ):
     assert check_keys_match(traj1, traj2)
 
-    for k in get_keys(traj1):
+    for k in traj1.keys():
         assert not torch.allclose(
             traj2[k], traj1[k]
         ), f"Trajectories are identical in state trajectory of variable {k}, but should differ."

--- a/tests/dynamical/test_dynamic_interventions.py
+++ b/tests/dynamical/test_dynamic_interventions.py
@@ -14,7 +14,7 @@ from chirho.dynamical.handlers import (
     LogTrajectory,
 )
 from chirho.dynamical.handlers.solver import TorchDiffEq
-from chirho.dynamical.ops import State, get_keys, simulate
+from chirho.dynamical.ops import State, simulate
 from chirho.indexed.ops import IndexSet, gather, indices_of, union
 
 from .dynamical_fixtures import UnifiedFixtureDynamics
@@ -273,7 +273,7 @@ def test_split_twinworld_dynamic_intervention(
 
     with cf:
         cf_trajectory = dt.trajectory
-        for k in get_keys(cf_trajectory):
+        for k in cf_trajectory.keys():
             # TODO: Figure out why event_dim=1 is not needed with cf_state but is with cf_trajectory.
             assert cf.default_name in indices_of(cf_state[k])
             assert cf.default_name in indices_of(cf_trajectory[k], event_dim=1)
@@ -321,7 +321,7 @@ def test_split_multiworld_dynamic_intervention(
 
     with cf:
         cf_trajectory = dt.trajectory
-        for k in get_keys(cf_trajectory):
+        for k in cf_trajectory.keys():
             # TODO: Figure out why event_dim=1 is not needed with cf_state but is with cf_trajectory.
             assert cf.default_name in indices_of(cf_state[k])
             assert cf.default_name in indices_of(cf_trajectory[k], event_dim=1)
@@ -392,15 +392,15 @@ def test_split_twinworld_dynamic_matches_output(
         assert not set(indices_of(cf_actual, event_dim=0))
         assert not set(indices_of(factual_actual, event_dim=0))
 
-    assert get_keys(cf_result) == get_keys(cf_actual) == get_keys(cf_expected)
-    assert get_keys(cf_result) == get_keys(factual_actual) == get_keys(factual_expected)
+    assert cf_result.keys() == cf_actual.keys() == cf_expected.keys()
+    assert cf_result.keys() == factual_actual.keys() == factual_expected.keys()
 
-    for k in get_keys(cf_result):
+    for k in cf_result.keys():
         assert torch.allclose(
             cf_actual[k], cf_expected[k], atol=1e-3, rtol=0
         ), f"Trajectories differ in state result of variable {k}, but should be identical."
 
-    for k in get_keys(cf_result):
+    for k in cf_result.keys():
         assert torch.allclose(
             factual_actual[k],
             factual_expected[k],

--- a/tests/dynamical/test_log_trajectory.py
+++ b/tests/dynamical/test_log_trajectory.py
@@ -6,7 +6,7 @@ import torch
 from chirho.dynamical.handlers import InterruptionEventLoop, LogTrajectory
 from chirho.dynamical.handlers.solver import TorchDiffEq
 from chirho.dynamical.internals._utils import append
-from chirho.dynamical.ops import State, get_keys, simulate
+from chirho.dynamical.ops import State, simulate
 
 from .dynamical_fixtures import bayes_sir_model, check_states_match
 
@@ -40,17 +40,17 @@ def test_logging():
     assert isinstance(result1, State)
     assert isinstance(dt1.trajectory, State)
     assert isinstance(dt2.trajectory, State)
-    assert len(get_keys(dt1.trajectory)) == 3
-    assert len(get_keys(dt2.trajectory)) == 3
-    assert get_keys(dt1.trajectory) == get_keys(result1)
-    assert get_keys(dt2.trajectory) == get_keys(result2)
+    assert len(dt1.trajectory.keys()) == 3
+    assert len(dt2.trajectory.keys()) == 3
+    assert dt1.trajectory.keys() == result1.keys()
+    assert dt2.trajectory.keys() == result2.keys()
     assert check_states_match(result1, result2)
     assert check_states_match(result1, result3)
 
 
 def test_trajectory_methods():
     trajectory = State(S=torch.tensor([1.0, 2.0, 3.0]))
-    assert get_keys(trajectory) == frozenset({"S"})
+    assert trajectory.keys() == frozenset({"S"})
 
 
 def test_append():

--- a/tests/dynamical/test_static_interventions.py
+++ b/tests/dynamical/test_static_interventions.py
@@ -13,7 +13,7 @@ from chirho.dynamical.handlers import (
     StaticIntervention,
 )
 from chirho.dynamical.handlers.solver import TorchDiffEq
-from chirho.dynamical.ops import State, get_keys, simulate
+from chirho.dynamical.ops import State, simulate
 from chirho.indexed.ops import IndexSet, gather, indices_of
 from chirho.interventional.ops import intervene
 
@@ -241,7 +241,7 @@ def test_twinworld_point_intervention(
 
     with cf:
         cf_trajectory = dt.trajectory
-        for k in get_keys(cf_trajectory):
+        for k in cf_trajectory.keys():
             # TODO: Figure out why event_dim=1 is not needed with cf_state but is with cf_trajectory.
             assert cf.default_name in indices_of(cf_state[k])
             assert cf.default_name in indices_of(cf_trajectory[k], event_dim=1)
@@ -276,7 +276,7 @@ def test_multiworld_point_intervention(
 
     with cf:
         cf_trajectory = dt.trajectory
-        for k in get_keys(cf_trajectory):
+        for k in cf_trajectory.keys():
             # TODO: Figure out why event_dim=1 is not needed with cf_state but is with cf_trajectory.
             assert cf.default_name in indices_of(cf_state[k])
             assert cf.default_name in indices_of(cf_trajectory[k], event_dim=1)
@@ -300,7 +300,7 @@ def test_split_odeint_broadcast(
 
     with cf:
         trajectory = dt.trajectory
-        for k in get_keys(trajectory):
+        for k in trajectory.keys():
             assert len(indices_of(trajectory[k], event_dim=1)) > 0
 
 
@@ -353,15 +353,15 @@ def test_twinworld_matches_output(
         assert not set(indices_of(cf_actual, event_dim=0))
         assert not set(indices_of(factual_actual, event_dim=0))
 
-    assert get_keys(cf_state) == get_keys(cf_actual) == get_keys(cf_expected)
-    assert get_keys(cf_state) == get_keys(factual_actual) == get_keys(factual_expected)
+    assert cf_state.keys() == cf_actual.keys() == cf_expected.keys()
+    assert cf_state.keys() == factual_actual.keys() == factual_expected.keys()
 
-    for k in get_keys(cf_state):
+    for k in cf_state.keys():
         assert torch.allclose(
             cf_actual[k], cf_expected[k]
         ), f"States differ in state trajectory of variable {k}, but should be identical."
 
-    for k in get_keys(cf_state):
+    for k in cf_state.keys():
         assert torch.allclose(
             factual_actual[k], factual_expected[k]
         ), f"States differ in state trajectory of variable {k}, but should be identical."


### PR DESCRIPTION
After #346 changed `State` to a vanilla `dict`, the `get_keys` operation added in #331 is no longer necessary. This refactoring PR removes `get_keys` and replaces it with `dict.keys`.