### PR TITLE
Separate `simulate` from `simulate_to_interruption`

### DIFF
--- a/chirho/dynamical/handlers/interruption.py
+++ b/chirho/dynamical/handlers/interruption.py
@@ -7,7 +7,6 @@ import torch
 
 from chirho.dynamical.handlers.trajectory import LogTrajectory
 from chirho.dynamical.ops import State
-from chirho.indexed.ops import get_index_plates, indices_of
 from chirho.interventional.ops import Intervention, intervene
 from chirho.observational.ops import Observation, observe
 
@@ -23,7 +22,7 @@ class Interruption(pyro.poutine.messenger.Messenger):
         self.used = False
         return super().__enter__()
 
-    def _pyro_simulate_to_interruption(self, msg) -> None:
+    def _pyro_get_next_interruptions(self, msg) -> None:
         raise NotImplementedError("shouldn't be here!")
 
 
@@ -34,7 +33,7 @@ class StaticInterruption(Interruption):
         self.time = torch.as_tensor(time)  # TODO enforce this where it is needed
         super().__init__()
 
-    def _pyro_simulate_to_interruption(self, msg) -> None:
+    def _pyro_get_next_interruptions(self, msg) -> None:
         _, _, _, start_time, end_time = msg["args"]
 
         if start_time < self.time < end_time:
@@ -67,7 +66,7 @@ class DynamicInterruption(Generic[T], Interruption):
         self.event_f = event_f
         super().__init__()
 
-    def _pyro_simulate_to_interruption(self, msg) -> None:
+    def _pyro_get_next_interruptions(self, msg) -> None:
         msg["kwargs"].setdefault("dynamic_interruptions", []).append(self)
 
 
@@ -157,21 +156,4 @@ class StaticBatchObservation(Generic[T], LogTrajectory[T]):
         super().__init__(times, eps=eps)
 
     def _pyro_post_simulate(self, msg) -> None:
-        super()._pyro_post_simulate(msg)
-
-        # This checks whether the simulate has already redirected in a InterruptionEventLoop.
-        # If so, we don't want to run the observation again.
-        if msg.setdefault("in_SEL", False):
-            return
-
-        # TODO remove this redundant check by fixing semantics of LogTrajectory and simulate
-        name_to_dim = {k: f.dim - 1 for k, f in get_index_plates().items()}
-        name_to_dim["__time"] = -1
-        len_traj = (
-            0
-            if len(self.trajectory.keys()) == 0
-            else 1 + max(indices_of(self.trajectory, name_to_dim=name_to_dim)["__time"])
-        )
-
-        if len_traj == len(self.times):
-            msg["value"] = observe(self.trajectory, self.observation)
+        self.trajectory = observe(self.trajectory, self.observation)

--- a/chirho/dynamical/internals/solver.py
+++ b/chirho/dynamical/internals/solver.py
@@ -8,7 +8,7 @@ from typing import List, Optional, Tuple, TypeVar, Union
 import pyro
 import torch
 
-from chirho.dynamical.ops import Dynamics, State, simulate
+from chirho.dynamical.ops import Dynamics, State
 
 if typing.TYPE_CHECKING:
     from chirho.dynamical.handlers.interruption import (
@@ -80,37 +80,14 @@ def simulate_to_interruption(
     start_state: State[T],
     start_time: R,
     end_time: R,
-    *,
-    next_static_interruption: Optional[StaticInterruption] = None,
-    dynamic_interruptions: List[DynamicInterruption] = [],
     **kwargs,
-) -> Tuple[State[T], Tuple[Interruption, ...], R]:
+) -> State[T]:
     """
-    Simulate a dynamical system until the next interruption. This will be either one of the passed
-    dynamic interruptions, the next static interruption, or the end time, whichever comes first.
+    Simulate a dynamical system until the next interruption.
 
-    :returns: the final state, a collection of interruptions that ended the simulation
-      (this will usually just be a single interruption), and the time the interruption occurred.
+    :returns: the final state
     """
-
-    interruptions, interruption_time = get_next_interruptions(
-        solver,
-        dynamics,
-        start_state,
-        start_time,
-        end_time,
-        next_static_interruption=next_static_interruption,
-        dynamic_interruptions=dynamic_interruptions,
-        **kwargs,
-    )
-    # TODO: consider memoizing results of `get_next_interruptions` to avoid recomputing
-    #  the solver in the dynamic setting. The interactions are a bit tricky here though, as we couldn't be in
-    #  a LogTrajectory context.
-    event_state = simulate(
-        dynamics, start_state, start_time, interruption_time, solver=solver
-    )
-
-    return event_state, interruptions, interruption_time
+    return simulate_point(solver, dynamics, start_state, start_time, end_time, **kwargs)
 
 
 @pyro.poutine.runtime.effectful(type="apply_interruptions")
@@ -124,6 +101,7 @@ def apply_interruptions(
     return dynamics, start_state
 
 
+@pyro.poutine.runtime.effectful(type="get_next_interruptions")
 def get_next_interruptions(
     solver: Solver,
     dynamics: Dynamics[T],

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -1,6 +1,6 @@
 import numbers
 import typing
-from typing import Callable, Dict, Generic, Optional, TypeVar, Union
+from typing import Callable, Dict, FrozenSet, Generic, Optional, TypeVar, Union
 
 import pyro
 import torch
@@ -12,6 +12,10 @@ T = TypeVar("T")
 
 class State(Generic[T], Dict[str, T]):
     pass
+
+
+def get_keys(state: State[T]) -> FrozenSet[str]:
+    return frozenset(state.keys())
 
 
 Dynamics = Callable[[State[T]], State[T]]
@@ -30,9 +34,13 @@ def simulate(
     """
     Simulate a dynamical system.
     """
-    from chirho.dynamical.internals.solver import Solver, get_solver, simulate_point
+    from chirho.dynamical.internals.solver import (
+        Solver,
+        get_solver,
+        simulate_to_interruption,
+    )
 
     solver_: Solver = get_solver() if solver is None else typing.cast(Solver, solver)
-    return simulate_point(
+    return simulate_to_interruption(
         solver_, dynamics, initial_state, start_time, end_time, **kwargs
     )

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -1,6 +1,6 @@
 import numbers
 import typing
-from typing import Callable, Dict, FrozenSet, Generic, Optional, TypeVar, Union
+from typing import Callable, Dict, Generic, Optional, TypeVar, Union
 
 import pyro
 import torch
@@ -12,10 +12,6 @@ T = TypeVar("T")
 
 class State(Generic[T], Dict[str, T]):
     pass
-
-
-def get_keys(state: State[T]) -> FrozenSet[str]:
-    return frozenset(state.keys())
 
 
 Dynamics = Callable[[State[T]], State[T]]


### PR DESCRIPTION
This small refactoring PR distinguishes between `simulate`, which is now only a user-facing interface for executing simulations of dynamical systems, from `simulate_to_interruption`, which is called repeatedly within an `InterruptionEventLoop`. This reduces the need for specialized messages in the `InterruptionEventLoop` handler and dramatically simplifies the interaction between `StaticBatchObservation` and the various operations.