### PR TITLE
Remove eps from core dynamics module, instead relying on backend-specific implementations to handle time collisions

### DIFF
--- a/chirho/dynamical/handlers/interruption.py
+++ b/chirho/dynamical/handlers/interruption.py
@@ -102,13 +102,11 @@ class StaticObservation(Generic[T], StaticInterruption, _PointObservationMixin[T
         self,
         time: R,
         observation: Observation[State[T]],
-        *,
-        eps: float = 1e-6,
     ):
         self.observation = observation
         # Add a small amount of time to the observation time to ensure that
         # the observation occurs after the logging period.
-        super().__init__(time + eps)
+        super().__init__(time)
 
 
 class StaticIntervention(Generic[T], StaticInterruption, _InterventionMixin[T]):
@@ -149,11 +147,9 @@ class StaticBatchObservation(Generic[T], LogTrajectory[T]):
         self,
         times: torch.Tensor,
         observation: Observation[State[T]],
-        *,
-        eps: float = 1e-6,
     ):
         self.observation = observation
-        super().__init__(times, eps=eps)
+        super().__init__(times)
 
     def _pyro_post_simulate(self, msg) -> None:
         self.trajectory = observe(self.trajectory, self.observation)

--- a/chirho/dynamical/handlers/trajectory.py
+++ b/chirho/dynamical/handlers/trajectory.py
@@ -14,10 +14,8 @@ T = TypeVar("T")
 class LogTrajectory(Generic[T], pyro.poutine.messenger.Messenger):
     trajectory: State[T]
 
-    def __init__(self, times: torch.Tensor, *, eps: float = 1e-6):
-        # Adding epsilon to the logging times to avoid collision issues with the logging times being exactly on the
-        #  boundaries of the simulation times. This is a hack, but it's a hack that should work for now.
-        self.times = times + eps
+    def __init__(self, times: torch.Tensor):
+        self.times = times
 
         # Require that the times are sorted. This is required by the index masking we do below.
         if not torch.all(self.times[1:] > self.times[:-1]):

--- a/chirho/dynamical/internals/backends/torchdiffeq.py
+++ b/chirho/dynamical/internals/backends/torchdiffeq.py
@@ -51,7 +51,10 @@ def _torchdiffeq_ode_simulate_inner(
     diff = timespan[:-1] < timespan[1:]
 
     # We should only encounter collisions at the beginning or end of the timespan.
-    assert torch.all(diff[1:-1])
+    if not torch.all(diff[1:-1]):
+        raise ValueError(
+            "elements of timespan must be strictly increasing, except at endpoints where interruptions can occur."
+        )
 
     # Add a leading "true" to diff for masking, as we've excluded the first element.
     timespan_ = timespan[torch.cat((torch.tensor([True]), diff))]

--- a/chirho/dynamical/internals/backends/torchdiffeq.py
+++ b/chirho/dynamical/internals/backends/torchdiffeq.py
@@ -48,12 +48,38 @@ def _torchdiffeq_ode_simulate_inner(
 ):
     var_order = _var_order(frozenset(initial_state.keys()))  # arbitrary, but fixed
 
-    solns = _batched_odeint(  # torchdiffeq.odeint(
-        functools.partial(_deriv, dynamics, var_order),
-        tuple(initial_state[v] for v in var_order),
-        timespan,
-        **odeint_kwargs,
-    )
+    diff = timespan[:-1] < timespan[1:]
+
+    # We should only encounter collisions at the beginning or end of the timespan.
+    assert torch.all(diff[1:-1])
+
+    # Add a leading "true" to diff for masking, as we've excluded the first element.
+    timespan_ = timespan[torch.cat((torch.tensor([True]), diff))]
+
+    # time_dim is set to -1 by convention.
+    # TODO: change this when time dim is allowed to vary.
+    time_dim = -1
+
+    if torch.any(diff):
+        solns = _batched_odeint(  # torchdiffeq.odeint(
+            functools.partial(_deriv, dynamics, var_order),
+            tuple(initial_state[v] for v in var_order),
+            timespan_,
+            **odeint_kwargs,
+        )
+    else:
+        solns = tuple(initial_state[v].unsqueeze(time_dim) for v in var_order)
+
+    # As we've already asserted that collisions only happen at the beginning or end of the timespan, we can just
+    #  concatenate the initial and final states to get the full trajectory if there are collisions.
+    if not diff[0].item():
+        solns = tuple(
+            torch.cat((s[..., 0].unsqueeze(time_dim), s), dim=time_dim) for s in solns
+        )
+    if not diff[-1].item() and len(diff) > 1:
+        solns = tuple(
+            torch.cat((s, s[..., -1].unsqueeze(time_dim)), dim=time_dim) for s in solns
+        )
 
     trajectory: State[torch.Tensor] = State()
     for var, soln in zip(var_order, solns):

--- a/tests/dynamical/test_noop_interruptions.py
+++ b/tests/dynamical/test_noop_interruptions.py
@@ -24,8 +24,6 @@ init_state_values = State(
     S=torch.tensor(10.0), I=torch.tensor(3.0), R=torch.tensor(1.0)
 )
 
-eps = 1e-3
-
 intervene_states = [
     State(S=torch.tensor(11.0)),
     State(I=torch.tensor(9.0)),
@@ -45,7 +43,7 @@ def test_noop_point_interruptions(model, init_state, start_time, end_time):
 
     # Test with standard point interruptions within timespan.
     with InterruptionEventLoop():
-        with StaticInterruption(time=end_time / 2.0 + eps):
+        with StaticInterruption(time=end_time / 2.0):
             result_pint = simulate(
                 model, init_state, start_time, end_time, solver=TorchDiffEq()
             )
@@ -55,9 +53,9 @@ def test_noop_point_interruptions(model, init_state, start_time, end_time):
     # Test with two standard point interruptions.
     with InterruptionEventLoop():
         with StaticInterruption(
-            time=end_time / 4.0 + eps
+            time=end_time / 4.0
         ):  # roughly 1/4 of the way through the timespan
-            with StaticInterruption(time=(end_time / 4.0) * 3 + eps):  # roughly 3/4
+            with StaticInterruption(time=(end_time / 4.0) * 3):  # roughly 3/4
                 result_double_pint1 = simulate(
                     model, init_state, start_time, end_time, solver=TorchDiffEq()
                 )
@@ -66,8 +64,8 @@ def test_noop_point_interruptions(model, init_state, start_time, end_time):
 
     # Test with two standard point interruptions, in a different order.
     with InterruptionEventLoop():
-        with StaticInterruption(time=(end_time / 4.0) * 3 + eps):  # roughly 3/4
-            with StaticInterruption(time=end_time / 4.0 + eps):  # roughly 1/3
+        with StaticInterruption(time=(end_time / 4.0) * 3):  # roughly 3/4
+            with StaticInterruption(time=end_time / 4.0):  # roughly 1/3
                 result_double_pint2 = simulate(
                     model, init_state, start_time, end_time, solver=TorchDiffEq()
                 )

--- a/tests/dynamical/test_static_interventions.py
+++ b/tests/dynamical/test_static_interventions.py
@@ -46,9 +46,6 @@ intervene_states = [
 intervene_times = (logging_times - 0.5).tolist()
 
 
-eps = 1e-3
-
-
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
 @pytest.mark.parametrize("init_state", [init_state_values])
 @pytest.mark.parametrize("start_time", [start_time])


### PR DESCRIPTION
Addresses #357 .

This PR removes `eps` from all interruptions and modifies the behavior of the torchdiffeq backend to mask and then concatenate the simulation endpoints if there are time collisions.