### PR TITLE
Add error handling and warning when interruption is outside of `simulate` start and end time

### DIFF
--- a/tests/dynamical/test_static_interventions.py
+++ b/tests/dynamical/test_static_interventions.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 # Points at which to measure the state of the system.
 start_time = torch.tensor(0.0)
 end_time = torch.tensor(10.0)
-logging_times = torch.linspace(start_time + 1, end_time - 2, 5)
+logging_times = torch.linspace(start_time + 0.01, end_time - 2, 5)
 
 # Initial state of the system.
 init_state_values = State(


### PR DESCRIPTION
Somewhere in this milestone (https://github.com/BasisResearch/chirho/milestone/8?closed=1), we removed the `ValueError` and `warning` behavior when interruptions occur before the start of a `simulate` or after the end of a `simulate`. Before this PR the test suite included tests that asserted this error handling behavior, but were never actually executed because of the particular choices of intervention times chosen in the tests.

To demonstrate this, the first commit ([8ab0e5d](https://github.com/BasisResearch/chirho/pull/359/commits/8ab0e5d32bcc011635f60c0c9907afad32aaf984)) in this PR simply modifies the culprit test to include interventions that occur before the start of the `simulate`. As expected, this test fails, as the `ValueError` was previously removed.

The following commits fix the behavior by adding a `_pyro_simulate` method to the `StaticInterruption` handler. After #356 , this unambiguously applies only during the user-facing `simulate` calls, and not the internal `simulate_to_interruption` calls.