### PR TITLE
Add shallow effect handler base class

### DIFF
--- a/tests/dynamical/test_handler_composition.py
+++ b/tests/dynamical/test_handler_composition.py
@@ -12,6 +12,7 @@ from chirho.dynamical.handlers import (
     StaticIntervention,
 )
 from chirho.dynamical.handlers.solver import TorchDiffEq
+from chirho.dynamical.internals._utils import ShallowMessenger
 from chirho.dynamical.ops import State, simulate
 from chirho.observational.handlers import condition
 from chirho.observational.handlers.soft_conditioning import AutoSoftConditioning
@@ -135,3 +136,36 @@ def test_smoke_inference_twincounterfactual_observation_intervention_commutes():
     )
     # Noise is shared between factual and counterfactual worlds.
     assert pred["u_ip"].squeeze().shape == (num_samples, len(flight_landing_times))
+
+
+def test_shallow_handler():
+    class ShallowLogSample(ShallowMessenger):
+        log: set
+
+        def __enter__(self):
+            self.log = set()
+            return super().__enter__()
+
+        def _pyro_sample(self, msg):
+            self.log.add(msg["name"])
+            pyro.sample(f"{msg['name']}__2", pyro.distributions.Bernoulli(0.5))
+
+    with pyro.poutine.trace() as tr1:
+        with ShallowLogSample() as h1, ShallowLogSample() as h2:
+            pyro.sample("a", pyro.distributions.Bernoulli(0.5))
+            with pyro.poutine.trace() as tr2, ShallowLogSample() as h3:
+                pyro.sample("b", pyro.distributions.Bernoulli(0.5))
+
+        with ShallowLogSample() as h4, pyro.poutine.block(hide_types=["sample"]):
+            pyro.sample("c", pyro.distributions.Bernoulli(0.5))
+            with ShallowLogSample() as h5:
+                pyro.sample("d", pyro.distributions.Bernoulli(0.5))
+
+    assert h1.log == {"a__2"}
+    assert h2.log == {"a"}
+    assert h3.log == {"b"}
+    assert h4.log == set()
+    assert h5.log == {"d"}
+
+    assert set(tr1.trace.nodes.keys()) == {"a", "a__2", "a__2__2", "b", "b__2"}
+    assert set(tr2.trace.nodes.keys()) == {"b", "b__2"}


### PR DESCRIPTION
Part of addressing performance and design issues related to #354 #160 

This PR adds an abstract "shallow" effect handler class `ShallowMessenger` to `chirho.dynamical.internals._utils` that exits after handling a single operation call. In a followup PR, I will use `ShallowMessenger` as a base class for `chirho.dynamical.handlers.interruption.Interruption`.