### PR TITLE
Fix bugged interaction between `LogTrajectory` and `Interruption` when times collide

### DIFF
--- a/chirho/dynamical/handlers/trajectory.py
+++ b/chirho/dynamical/handlers/trajectory.py
@@ -35,7 +35,7 @@ class LogTrajectory(Generic[T], pyro.poutine.messenger.Messenger):
         solver, dynamics, initial_state, start_time, end_time = msg["args"]
 
         filtered_timespan = self.times[
-            (self.times >= start_time) & (self.times <= end_time)
+            (self.times > start_time) & (self.times <= end_time)
         ]
         timespan = torch.concat(
             (start_time.unsqueeze(-1), filtered_timespan, end_time.unsqueeze(-1))

--- a/tests/dynamical/test_log_trajectory.py
+++ b/tests/dynamical/test_log_trajectory.py
@@ -3,7 +3,11 @@ import logging
 import pyro
 import torch
 
-from chirho.dynamical.handlers import InterruptionEventLoop, LogTrajectory
+from chirho.dynamical.handlers import (
+    InterruptionEventLoop,
+    LogTrajectory,
+    StaticInterruption,
+)
 from chirho.dynamical.handlers.solver import TorchDiffEq
 from chirho.dynamical.internals._utils import append
 from chirho.dynamical.ops import State, simulate
@@ -46,6 +50,27 @@ def test_logging():
     assert dt2.trajectory.keys() == result2.keys()
     assert check_states_match(result1, result2)
     assert check_states_match(result1, result3)
+
+
+def test_logging_with_colliding_interruption():
+    sir = bayes_sir_model()
+    with LogTrajectory(
+        times=logging_times,
+    ) as dt1:
+        simulate(sir, init_state, start_time, end_time, solver=TorchDiffEq())
+
+    with LogTrajectory(
+        times=logging_times,
+    ) as dt2:
+        with InterruptionEventLoop():
+            with StaticInterruption(
+                time=torch.tensor(2.0),
+            ):
+                simulate(
+                    sir, init_state, start_time, end_time, solver=TorchDiffEq()
+                )
+    
+    check_states_match(dt1.trajectory, dt2.trajectory)
 
 
 def test_trajectory_methods():

--- a/tests/dynamical/test_log_trajectory.py
+++ b/tests/dynamical/test_log_trajectory.py
@@ -66,10 +66,8 @@ def test_logging_with_colliding_interruption():
             with StaticInterruption(
                 time=torch.tensor(2.0),
             ):
-                simulate(
-                    sir, init_state, start_time, end_time, solver=TorchDiffEq()
-                )
-    
+                simulate(sir, init_state, start_time, end_time, solver=TorchDiffEq())
+
     check_states_match(dt1.trajectory, dt2.trajectory)
 
 


### PR DESCRIPTION
This small PR fixes a bug where adding an interruption that collides with an element in the `times` argument of `LogTrajectory` resulted in an additional element being added to the resulting `trajectory`. The first commit (583bb37) introduces a test that previously failed as demonstrated by the CI build. The second commit (297b670) introduces a simple fix by adding interruptions at the end of a time subspan only, as opposed to at the beginning and end previously.