### PR TITLE
Separate cond_n and scatter_n from cond and scatter

### DIFF
--- a/chirho/counterfactual/handlers/explanation.py
+++ b/chirho/counterfactual/handlers/explanation.py
@@ -9,7 +9,7 @@ import torch
 
 from chirho.counterfactual.handlers.counterfactual import Preemptions
 from chirho.counterfactual.handlers.selection import get_factual_indices
-from chirho.indexed.ops import IndexSet, cond, gather, indices_of, scatter
+from chirho.indexed.ops import IndexSet, cond, gather, indices_of, scatter_n
 from chirho.interventional.handlers import do
 from chirho.interventional.ops import Intervention
 from chirho.observational.handlers.condition import Factors
@@ -43,7 +43,7 @@ def undo_split(antecedents: Iterable[str] = [], event_dim: int = 0) -> Callable[
         )
 
         # TODO exponential in len(antecedents) - add an indexed.ops.expand to do this cheaply
-        return scatter(
+        return scatter_n(
             {
                 IndexSet(
                     **{antecedent: {ind} for antecedent, ind in zip(antecedents_, inds)}

--- a/chirho/counterfactual/ops.py
+++ b/chirho/counterfactual/ops.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple, TypeVar
 
 import pyro
 
-from chirho.indexed.ops import IndexSet, cond, scatter
+from chirho.indexed.ops import IndexSet, cond_n, scatter_n
 from chirho.interventional.ops import Intervention, intervene
 
 S = TypeVar("S")
@@ -37,7 +37,7 @@ def split(obs: T, acts: Tuple[Intervention[T], ...], **kwargs) -> T:
     for i, act in enumerate(acts):
         act_values[IndexSet(**{name: {i + 1}})] = intervene(obs, act, **kwargs)
 
-    return scatter(act_values, event_dim=kwargs.get("event_dim", 0))
+    return scatter_n(act_values, event_dim=kwargs.get("event_dim", 0))
 
 
 @pyro.poutine.runtime.effectful(type="preempt")
@@ -69,4 +69,4 @@ def preempt(
     for i, act in enumerate(acts):
         act_values[IndexSet(**{name: {i + 1}})] = intervene(obs, act, **kwargs)
 
-    return cond(act_values, case, event_dim=kwargs.get("event_dim", 0))
+    return cond_n(act_values, case, event_dim=kwargs.get("event_dim", 0))

--- a/chirho/indexed/ops.py
+++ b/chirho/indexed/ops.py
@@ -248,9 +248,8 @@ def scatter(
     raise NotImplementedError
 
 
-@scatter.register(dict)
 @pyro.poutine.runtime.effectful(type="scatter_n")
-def _scatter_n(values: Dict[IndexSet, T], *, result: Optional[T] = None, **kwargs):
+def scatter_n(values: Dict[IndexSet, T], *, result: Optional[T] = None, **kwargs):
     """
     Scatters a dictionary of disjoint masked values into a single value
     using repeated calls to :func:``scatter``.
@@ -296,9 +295,8 @@ def cond(fst, snd, case: Optional[T] = None, **kwargs):
     raise NotImplementedError(f"cond not implemented for {type(fst)}")
 
 
-@cond.register(dict)
 @pyro.poutine.runtime.effectful(type="cond_n")
-def _cond_n(values: Dict[IndexSet, T], case: Union[bool, torch.Tensor], **kwargs):
+def cond_n(values: Dict[IndexSet, T], case: Union[bool, torch.Tensor], **kwargs):
     assert len(values) > 0
     assert all(isinstance(k, IndexSet) for k in values.keys())
     result: Optional[T] = None

--- a/chirho/observational/handlers/cut.py
+++ b/chirho/observational/handlers/cut.py
@@ -4,7 +4,7 @@ import pyro
 import torch
 
 from chirho.indexed.handlers import DependentMaskMessenger, add_indices
-from chirho.indexed.ops import IndexSet, gather, indexset_as_mask, scatter
+from chirho.indexed.ops import IndexSet, gather, indexset_as_mask, scatter_n
 
 T = TypeVar("T")
 
@@ -100,7 +100,7 @@ class SingleStageCut(DependentMaskMessenger):
                 event_dim=msg["fn"].event_dim,
             )
 
-            msg["value"] = scatter(
+            msg["value"] = scatter_n(
                 {
                     IndexSet(**{self.name: {0}}): value_one,
                     IndexSet(**{self.name: {1}}): value_one.detach(),

--- a/tests/indexed/test_internals.py
+++ b/tests/indexed/test_internals.py
@@ -11,11 +11,13 @@ from chirho.indexed.internals import add_indices
 from chirho.indexed.ops import (
     IndexSet,
     cond,
+    cond_n,
     gather,
     get_index_plates,
     indexset_as_mask,
     indices_of,
     scatter,
+    scatter_n,
     union,
 )
 
@@ -386,7 +388,7 @@ def test_persistent_index_state(enum_shape, plate_shape, batch_shape, event_shap
             )
 
     with index_state:
-        actual = scatter(
+        actual = scatter_n(
             {ind1: value1, ind2: value2}, result=result, event_dim=event_dim
         )
 
@@ -450,7 +452,7 @@ def test_cond_tensor_associate(enum_shape, batch_shape, plate_shape, event_shape
                 IndexSet(**{name: set(range(max(3, (batch_shape + plate_shape)[dim])))})
             )
 
-        actual_full = cond(
+        actual_full = cond_n(
             {ind1: value1, ind2: value2, ind3: value3}, case, event_dim=event_dim
         )
 


### PR DESCRIPTION
Addresses #350 

This refactoring PR promotes `cond_n` and `scatter_n` to separate operations in `chirho.ops.indexed`, rather than patterns of `cond` and `scatter`.

This change is necessary for #350 because reducing `dynamics.ops.State` to a type alias of `dict` would require new patterns for `dict` that would collide with the patterns corresponding to `cond_n` and `scatter_n`, which don't really make sense as specializations of the binary operations `cond` and `scatter` anyway.