### PR TITLE
Make State a type alias rather than a subtype

### DIFF
--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -1,6 +1,6 @@
 import numbers
 import typing
-from typing import Callable, Dict, Generic, Optional, TypeVar, Union
+from typing import Callable, Dict, Optional, TypeVar, Union
 
 import pyro
 import torch
@@ -10,9 +10,7 @@ S = TypeVar("S")
 T = TypeVar("T")
 
 
-class State(Generic[T], Dict[str, T]):
-    pass
-
+State = Dict[str, T]
 
 Dynamics = Callable[[State[T]], State[T]]
 

--- a/chirho/interventional/handlers.py
+++ b/chirho/interventional/handlers.py
@@ -1,6 +1,6 @@
 import collections
 import functools
-from typing import Callable, Generic, Hashable, Mapping, Optional, TypeVar
+from typing import Callable, Dict, Generic, Hashable, Mapping, Optional, TypeVar
 
 import pyro
 import torch
@@ -11,6 +11,7 @@ from chirho.interventional.ops import (
     intervene,
 )
 
+K = TypeVar("K")
 T = TypeVar("T")
 
 
@@ -53,6 +54,16 @@ def _intervene_atom_distribution(
     elif isinstance(act, tuple):
         return act[-1]
     return act
+
+
+@intervene.register(dict)
+def _dict_intervene(
+    obs: Dict[K, T], act: Dict[K, AtomicIntervention[T]], **kwargs
+) -> Dict[K, T]:
+    result: Dict[K, T] = {}
+    for k in obs.keys():
+        result[k] = intervene(obs[k], act[k] if k in act else None, **kwargs)
+    return result
 
 
 @intervene.register


### PR DESCRIPTION
Addresses #350. Blocked by #374.

This refactoring PR makes `chirho.dynamical.ops.State` into a type alias of `dict[str, T]`.