### PR TITLE
Speed up parallelized CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,5 +51,5 @@ jobs:
       - name: Test
         shell: bash
         run: |
-          pytest tests/ -s -n auto --cov=chirho/ --cov-report=term-missing ${@-}
+          MKL_NUM_THREADS=1 pytest tests/ -s -n auto --cov=chirho/ --cov-report=term-missing ${@-}
           cd docs && make html


### PR DESCRIPTION
This PR adds `MKL_NUM_THREADS=1` to the unit test run in our CI workflow. This environment variable restricts the maximum number of CPU threads that an Intel MKL implementation of a tensor operation can use. When running many small PyTorch computations in parallel processes on an Intel CPU, operation-level parallelism within kernels can interfere with process-level parallelism, resulting in significant slowdowns compared to executing operation kernels within the process that invoked them. This tweak seems to have reduced our unit test CI times by ~25%.

