### PR TITLE
Add linting actions for Python 3.9 and 3.10

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.9, '3.10']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR adds linting stages in CI for Python versions 3.9 and 3.10. This will help us track failures that are specific to different versions and provide evidence as we consider dropping support for Python 3.8 #282 