### PR TITLE
Rename DoMessenger and ConditionMessenger query handlers

### DIFF
--- a/chirho/interventional/handlers.py
+++ b/chirho/interventional/handlers.py
@@ -81,10 +81,10 @@ def _intervene_callable(
             return intervene(obs(*args, **kwargs), act(*args, **kwargs), **call_kwargs)
 
         return _intervene_callable_wrapper
-    return DoMessenger(actions=act)(obs)
+    return Interventions(actions=act)(obs)
 
 
-class DoMessenger(Generic[T], pyro.poutine.messenger.Messenger):
+class Interventions(Generic[T], pyro.poutine.messenger.Messenger):
     """
     Intervene on values in a probabilistic program.
 
@@ -116,4 +116,4 @@ class DoMessenger(Generic[T], pyro.poutine.messenger.Messenger):
         )
 
 
-do = pyro.poutine.handlers._make_handler(DoMessenger)[1]
+do = pyro.poutine.handlers._make_handler(Interventions)[1]

--- a/chirho/observational/handlers/condition.py
+++ b/chirho/observational/handlers/condition.py
@@ -54,7 +54,7 @@ class Factors(Generic[T], pyro.poutine.messenger.Messenger):
         pyro.factor(f"{self.prefix}{msg['name']}", factor(msg["value"]))
 
 
-class ConditionMessenger(Generic[T], ObserveNameMessenger):
+class Observations(Generic[T], ObserveNameMessenger):
     """
     Condition on values in a probabilistic program.
 
@@ -106,4 +106,4 @@ class ConditionMessenger(Generic[T], ObserveNameMessenger):
                 self._current_site = None
 
 
-condition = pyro.poutine.handlers._make_handler(ConditionMessenger)[1]
+condition = pyro.poutine.handlers._make_handler(Observations)[1]

--- a/tests/counterfactual/test_mediation.py
+++ b/tests/counterfactual/test_mediation.py
@@ -11,7 +11,7 @@ from chirho.counterfactual.handlers import (
     MultiWorldCounterfactual,
     TwinWorldCounterfactual,
 )
-from chirho.interventional.handlers import DoMessenger, do
+from chirho.interventional.handlers import Interventions, do
 from chirho.observational.handlers import condition
 
 logger = logging.getLogger(__name__)
@@ -68,7 +68,7 @@ def test_do_api(x_cf_value):
     model = make_mediation_model(*linear_fs())
 
     # These APIs should be equivalent
-    intervened_model_1 = DoMessenger({"X": x_cf_value})(model)
+    intervened_model_1 = Interventions({"X": x_cf_value})(model)
     intervened_model_2 = do(model, {"X": x_cf_value})
 
     W_1, X_1, Z_1, Y_1 = TwinWorldCounterfactual(-1)(intervened_model_1)()


### PR DESCRIPTION
Addresses #388 

This small refactoring PR renames the handlers `chirho.interventional.handlers.DoMessenger` and `chirho.observational.handlers.condition.ConditionMessenger` to `Interventions` and `Observations`, respectively.

Tests:
- Changes exercised by existing unit tests