### PR TITLE
Add `staging-*` to CI build

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, staging-* ]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, staging-* ]
 
 jobs:
   build:


### PR DESCRIPTION
This tiny PR adds all branches with `staging-` as the first characters of the branch name to the CI builds. This is a lower overhead alternative to having each staging branch manually change its github actions CI builds. See `staging-dynamics` and `staging-robust` for examples.

See #392 for demonstration that this worked.