### PR TITLE
Explanation module, actual causality and explanation notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,8 +79,10 @@ venv/
 
 # VSCode
 /.vscode
+*.code-workspace
 
 # Automatically generated files
+docs/source/lightning_logs
 docs/preconvert
 docs/build
 site/


### PR DESCRIPTION
Once the explanation-related code is separated into a module and the actual causality and explanation notebooks have been completed and merged into `ru-causality-staging`,  this should land in `master`.