### PR TITLE
Add upper bound on number of CG steps

### DIFF
--- a/chirho/robust/internals/linearize.py
+++ b/chirho/robust/internals/linearize.py
@@ -43,6 +43,8 @@ def _flat_conjugate_gradient_solve(
     """
     if cg_iters is None:
         cg_iters = b.numel()
+    else:
+        cg_iters = min(cg_iters, b.numel())
 
     p = b.clone()
     r = b.clone()
@@ -66,9 +68,6 @@ def _flat_conjugate_gradient_solve(
         p = torch.where(not_converged, r + mu * p, p)
         rdotr = torch.where(not_converged, newrdotr, rdotr)
 
-        # rdotr = newrdotr
-        # if rdotr < residual_tol:
-        #     break
     return x
 
 

--- a/chirho/robust/internals/linearize.py
+++ b/chirho/robust/internals/linearize.py
@@ -43,8 +43,6 @@ def _flat_conjugate_gradient_solve(
     """
     if cg_iters is None:
         cg_iters = b.numel()
-    else:
-        cg_iters = min(cg_iters, b.numel())
 
     p = b.clone()
     r = b.clone()
@@ -139,6 +137,11 @@ def linearize(
     log_prob_params, func_log_prob = make_functional_call(log_prob)
     score_fn = torch.func.grad(func_log_prob)
 
+    log_prob_params_numel: int = sum(p.numel() for p in log_prob_params.values())
+    if cg_iters is None:
+        cg_iters = log_prob_params_numel
+    else:
+        cg_iters = min(cg_iters, log_prob_params_numel)
     cg_solver = functools.partial(
         conjugate_gradient_solve, cg_iters=cg_iters, residual_tol=residual_tol
     )


### PR DESCRIPTION
Addresses @agrawalraj's comments in #398:
> If cg_iters is not None, then we should make sure it's less than or equal to the dimension of guide parameters (total_params) because conjugate gradients gives us the exact inverse vector product in at most total_params iterations.

