### PR TITLE
Minor update to ChiRho tutorial to remove unnecessary `to_event`

### DIFF
--- a/docs/source/tutorial_i.ipynb
+++ b/docs/source/tutorial_i.ipynb
@@ -790,7 +790,7 @@
     "\n",
     "def parameter_prior():\n",
     "\n",
-    "    stress_pt = pyro.sample(\"stress_pt\", Beta(torch.ones(1), torch.ones(1)).to_event(1))\n",
+    "    stress_pt = pyro.sample(\"stress_pt\", Beta(1., 1.))\n",
     "    smokes_cpt = pyro.sample(\"smokes_cpt\", Beta(torch.ones(2), torch.ones(2)).to_event(1))\n",
     "    cancer_cpt = pyro.sample(\"cancer_cpt\", Beta(torch.ones(2, 2), torch.ones(2, 2)).to_event(2)) \n",
     "\n",
@@ -1921,7 +1921,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.4"
   },
   "orig_nbformat": 4,
   "vscode": {


### PR DESCRIPTION
In cell 12 of the notebook we previously included a beta distribution over a 1-D tensor. This has been replaced with a scalar argument.