### PR TITLE
add `preempt` and its tests

### DIFF
--- a/chirho/explainable/ops.py
+++ b/chirho/explainable/ops.py
@@ -1,0 +1,42 @@
+import functools
+from typing import Optional, Tuple, TypeVar
+
+import pyro
+
+from chirho.indexed.ops import IndexSet, cond_n
+from chirho.interventional.ops import Intervention, intervene
+
+S = TypeVar("S")
+T = TypeVar("T")
+
+
+@pyro.poutine.runtime.effectful(type="preempt")
+@functools.partial(pyro.poutine.block, hide_types=["intervene"])
+def preempt(
+    obs: T, acts: Tuple[Intervention[T], ...], case: Optional[S] = None, **kwargs
+) -> T:
+    """
+    Effectful primitive operation for "preempting" values in a probabilistic program.
+
+    Unlike the counterfactual operation :func:`~chirho.counterfactual.ops.split`,
+    which returns multiple values concatenated along a new axis
+    via the operation :func:`~chirho.indexed.ops.scatter`,
+    :func:`preempt` returns a single value determined by the argument ``case``
+    via :func:`~chirho.indexed.ops.cond` .
+
+    In a probabilistic program, a :func:`preempt` call induces a mixture distribution
+    over downstream values, whereas :func:`split` would induce a joint distribution.
+
+    :param obs: The observed value.
+    :param acts: The interventions to apply.
+    :param case: The case to select.
+    """
+    if case is None:
+        return obs
+
+    name = kwargs.get("name", None)
+    act_values = {IndexSet(**{name: {0}}): obs}
+    for i, act in enumerate(acts):
+        act_values[IndexSet(**{name: {i + 1}})] = intervene(obs, act, **kwargs)
+
+    return cond_n(act_values, case, event_dim=kwargs.get("event_dim", 0))

--- a/tests/explainable/test_ops.py
+++ b/tests/explainable/test_ops.py
@@ -8,8 +8,9 @@ from chirho.counterfactual.handlers import (
     MultiWorldCounterfactual,
     SingleWorldCounterfactual,
 )
-from chirho.counterfactual.handlers.counterfactual import Preemptions
-from chirho.counterfactual.ops import preempt, split
+#from chirho.counterfactual.handlers.counterfactual import Preemptions
+from chirho.counterfactual.ops import split
+from chirho.explainable.ops import preempt
 from chirho.indexed.ops import IndexSet, indices_of
 from chirho.interventional.handlers import do
 
@@ -36,45 +37,3 @@ def test_preempt_op_singleworld():
     assert torch.all(tr.nodes["x_"]["value"] == 0.0)
     assert torch.all(tr.nodes["y_"]["value"] == 1.0)
 
-
-@pytest.mark.parametrize("cf_dim", [-2, -3, None])
-@pytest.mark.parametrize("event_shape", [(), (4,), (4, 3)])
-def test_cf_handler_preemptions(cf_dim, event_shape):
-    event_dim = len(event_shape)
-
-    splits = {"x": torch.tensor(0.0)}
-    preemptions = {"y": torch.tensor(1.0)}
-
-    @do(actions=splits)
-    @pyro.plate("data", size=1000, dim=-1)
-    def model():
-        w = pyro.sample(
-            "w", dist.Normal(0, 1).expand(event_shape).to_event(len(event_shape))
-        )
-        x = pyro.sample("x", dist.Normal(w, 1).to_event(len(event_shape)))
-        y = pyro.sample("y", dist.Normal(w + x, 1).to_event(len(event_shape)))
-        z = pyro.sample("z", dist.Normal(x + y, 1).to_event(len(event_shape)))
-        return dict(w=w, x=x, y=y, z=z)
-
-    preemption_handler = Preemptions(actions=preemptions, bias=0.1, prefix="__split_")
-
-    with MultiWorldCounterfactual(cf_dim), preemption_handler:
-        tr = pyro.poutine.trace(model).get_trace()
-        assert all(f"__split_{k}" in tr.nodes for k in preemptions.keys())
-        assert indices_of(tr.nodes["w"]["value"], event_dim=event_dim) == IndexSet()
-        assert indices_of(tr.nodes["y"]["value"], event_dim=event_dim) == IndexSet(
-            x={0, 1}
-        )
-        assert indices_of(tr.nodes["z"]["value"], event_dim=event_dim) == IndexSet(
-            x={0, 1}
-        )
-
-    for k in preemptions.keys():
-        tst = tr.nodes[f"__split_{k}"]["value"]
-        assert torch.allclose(
-            tr.nodes[f"__split_{k}"]["fn"].log_prob(torch.tensor(0)).exp(),
-            torch.tensor(0.5 - 0.1),
-        )
-        tst_0 = (tst == 0).expand(tr.nodes[k]["fn"].batch_shape)
-        assert torch.all(tr.nodes[k]["value"][~tst_0] == preemptions[k])
-        assert torch.all(tr.nodes[k]["value"][tst_0] != preemptions[k])

--- a/tests/explainable/test_ops.py
+++ b/tests/explainable/test_ops.py
@@ -1,18 +1,11 @@
 import pyro
 import pyro.distributions as dist
 import pyro.infer
-import pytest
 import torch
 
-from chirho.counterfactual.handlers import (
-    MultiWorldCounterfactual,
-    SingleWorldCounterfactual,
-)
-#from chirho.counterfactual.handlers.counterfactual import Preemptions
+from chirho.counterfactual.handlers import SingleWorldCounterfactual
 from chirho.counterfactual.ops import split
 from chirho.explainable.ops import preempt
-from chirho.indexed.ops import IndexSet, indices_of
-from chirho.interventional.handlers import do
 
 
 def test_preempt_op_singleworld():
@@ -36,4 +29,3 @@ def test_preempt_op_singleworld():
     tr = pyro.poutine.trace(model).get_trace()
     assert torch.all(tr.nodes["x_"]["value"] == 0.0)
     assert torch.all(tr.nodes["y_"]["value"] == 1.0)
-

--- a/tests/explainable/test_ops.py
+++ b/tests/explainable/test_ops.py
@@ -1,0 +1,80 @@
+import pyro
+import pyro.distributions as dist
+import pyro.infer
+import pytest
+import torch
+
+from chirho.counterfactual.handlers import (
+    MultiWorldCounterfactual,
+    SingleWorldCounterfactual,
+)
+from chirho.counterfactual.handlers.counterfactual import Preemptions
+from chirho.counterfactual.ops import preempt, split
+from chirho.indexed.ops import IndexSet, indices_of
+from chirho.interventional.handlers import do
+
+
+def test_preempt_op_singleworld():
+    @SingleWorldCounterfactual()
+    @pyro.plate("data", size=1000, dim=-1)
+    def model():
+        x = pyro.sample("x", dist.Bernoulli(0.67))
+        x = pyro.deterministic(
+            "x_", split(x, (torch.tensor(0.0),), name="x", event_dim=0), event_dim=0
+        )
+        y = pyro.sample("y", dist.Bernoulli(0.67))
+        y_case = torch.tensor(1)
+        y = pyro.deterministic(
+            "y_",
+            preempt(y, (torch.tensor(1.0),), y_case, name="__y", event_dim=0),
+            event_dim=0,
+        )
+        z = pyro.sample("z", dist.Bernoulli(0.67))
+        return dict(x=x, y=y, z=z)
+
+    tr = pyro.poutine.trace(model).get_trace()
+    assert torch.all(tr.nodes["x_"]["value"] == 0.0)
+    assert torch.all(tr.nodes["y_"]["value"] == 1.0)
+
+
+@pytest.mark.parametrize("cf_dim", [-2, -3, None])
+@pytest.mark.parametrize("event_shape", [(), (4,), (4, 3)])
+def test_cf_handler_preemptions(cf_dim, event_shape):
+    event_dim = len(event_shape)
+
+    splits = {"x": torch.tensor(0.0)}
+    preemptions = {"y": torch.tensor(1.0)}
+
+    @do(actions=splits)
+    @pyro.plate("data", size=1000, dim=-1)
+    def model():
+        w = pyro.sample(
+            "w", dist.Normal(0, 1).expand(event_shape).to_event(len(event_shape))
+        )
+        x = pyro.sample("x", dist.Normal(w, 1).to_event(len(event_shape)))
+        y = pyro.sample("y", dist.Normal(w + x, 1).to_event(len(event_shape)))
+        z = pyro.sample("z", dist.Normal(x + y, 1).to_event(len(event_shape)))
+        return dict(w=w, x=x, y=y, z=z)
+
+    preemption_handler = Preemptions(actions=preemptions, bias=0.1, prefix="__split_")
+
+    with MultiWorldCounterfactual(cf_dim), preemption_handler:
+        tr = pyro.poutine.trace(model).get_trace()
+        assert all(f"__split_{k}" in tr.nodes for k in preemptions.keys())
+        assert indices_of(tr.nodes["w"]["value"], event_dim=event_dim) == IndexSet()
+        assert indices_of(tr.nodes["y"]["value"], event_dim=event_dim) == IndexSet(
+            x={0, 1}
+        )
+        assert indices_of(tr.nodes["z"]["value"], event_dim=event_dim) == IndexSet(
+            x={0, 1}
+        )
+
+    for k in preemptions.keys():
+        tst = tr.nodes[f"__split_{k}"]["value"]
+        assert torch.allclose(
+            tr.nodes[f"__split_{k}"]["fn"].log_prob(torch.tensor(0)).exp(),
+            torch.tensor(0.5 - 0.1),
+        )
+        tst_0 = (tst == 0).expand(tr.nodes[k]["fn"].batch_shape)
+        assert torch.all(tr.nodes[k]["value"][~tst_0] == preemptions[k])
+        assert torch.all(tr.nodes[k]["value"][tst_0] != preemptions[k])


### PR DESCRIPTION
Resolves #413 .

Refactor `preempt` to live in the new `explainable` module in ops.py, add a corresponding folder and test file `test_ops.py`, containing a single world test for it .

Note: the other test involving `preempt` employs `Preemptions`, which has not been implemented. It will be re-introduced as the implementation proceeds.