### PR TITLE
Remove deprecated `event_loop` module from Sphinx

### DIFF
--- a/docs/source/dynamical.rst
+++ b/docs/source/dynamical.rst
@@ -19,10 +19,6 @@ Handlers
    :members:
    :undoc-members:
 
-.. automodule:: chirho.dynamical.handlers.event_loop
-   :members:
-   :undoc-members:
-
 .. automodule:: chirho.dynamical.handlers.interruption
    :members:
    :undoc-members:


### PR DESCRIPTION
After #395, there is no `chirho.dynamical.handlers.event_loop` module, but we forgot to remove it from the Sphinx autodoc file for `chirho.dynamical`. This PR does that, which fixes a Sphinx build warning triggered by the missing module.