### PR TITLE
Use Hessian formulation of Fisher information in `make_empirical_fisher_vp`

### DIFF
--- a/chirho/robust/internals/linearize.py
+++ b/chirho/robust/internals/linearize.py
@@ -96,7 +96,7 @@ def make_empirical_fisher_vp(
         randomness="different",
     )
 
-    N = data[next(iter(data))].shape[0]
+    N = data[next(iter(data))].shape[0]  # type: ignore
     mean_vector = 1 / N * torch.ones(N)
 
     def bound_batched_func_log_prob(params: ParamDict) -> torch.Tensor:

--- a/chirho/robust/internals/linearize.py
+++ b/chirho/robust/internals/linearize.py
@@ -103,9 +103,11 @@ def make_empirical_fisher_vp(
         return batched_func_log_prob(params, data)
 
     def _empirical_fisher_vp(v: ParamDict) -> ParamDict:
-        jvp_fn = lambda log_prob_params: torch.func.jvp(
-            bound_batched_func_log_prob, (log_prob_params,), (v,)
-        )[1]
+        def jvp_fn(log_prob_params: ParamDict) -> torch.Tensor:
+            return torch.func.jvp(
+                bound_batched_func_log_prob, (log_prob_params,), (v,)
+            )[1]
+
         # Perlmutter's trick
         vjp_fn = torch.func.vjp(jvp_fn, log_prob_params)[1]
         return vjp_fn(-1 * mean_vector)[0]  # Fisher = -E[Hessian]


### PR DESCRIPTION
This PR closes #428.

This function works as follows:

We would like to compute 

$$-\frac{1}{N}\sum_{n=1}^N \nabla^2_{\phi} \log q(\phi; x_n)v, $$

where $\phi$ are the guide parameters of type `ParamDict` and $v$ is an arbitrary vector of type `ParamDict`. Let $g_v(\phi) \coloneqq \nabla_{\phi}  \log q_{b}(\phi; X)v = \texttt{jvp}(g, \phi, v)$, where $q_b: \texttt{ParamDict} \mapsto \mathbb{R}^N$ denotes the batched density. Then, $g_v: \texttt{ParamDict} \mapsto \mathbb{R}^N$ and $\nabla_{\phi} g_v(\phi) \in \mathbb{R}^{N \times \texttt{ParamDict}}$. Hence, 

$$-\frac{1}{N}\sum_{n=1}^N \nabla^2_{\phi} \log q(\phi; x_n)v = -\mu \nabla_{\phi} g_v(\phi),$$ 

where $\mu = (1/N, \cdots, 1/N)$. Now, $-\mu \nabla_{\phi} g_v(\phi) = \texttt{vjp}(g_v, \phi, -\mu)$. 

Note: the above is a batched version of Perlmutter's trick.