### PR TITLE
Make State into a type alias of Mapping

### DIFF
--- a/chirho/dynamical/handlers/trajectory.py
+++ b/chirho/dynamical/handlers/trajectory.py
@@ -9,7 +9,7 @@ from chirho.dynamical.internals._utils import (
     append,
 )
 from chirho.dynamical.internals.solver import simulate_trajectory
-from chirho.dynamical.ops import State
+from chirho.dynamical.ops import Dynamics, State
 from chirho.indexed.ops import IndexSet, gather, get_index_plates
 
 T = TypeVar("T")
@@ -21,7 +21,7 @@ class LogTrajectory(Generic[T], pyro.poutine.messenger.Messenger):
 
     def __init__(self, times: torch.Tensor, is_traced: bool = False):
         self.times = times
-        self._trajectory: State[T] = State()
+        self._trajectory: State[T] = dict()
         self.is_traced = is_traced
 
         # Require that the times are sorted. This is required by the index masking we do below.
@@ -30,8 +30,8 @@ class LogTrajectory(Generic[T], pyro.poutine.messenger.Messenger):
 
         super().__init__()
 
-    def _pyro_post_simulate(self, msg) -> None:
-        initial_state = msg["args"][1]
+    def _pyro_post_simulate(self, msg: dict) -> None:
+        initial_state: State[T] = msg["args"][1]
         start_time = msg["args"][2]
 
         if start_time == self.times[0]:
@@ -39,13 +39,13 @@ class LogTrajectory(Generic[T], pyro.poutine.messenger.Messenger):
             # LogTrajectory's simulate_point will log only timepoints that are greater than the start_time of each
             # simulate_point call, which can occur multiple times in a single simulate call when there
             # are interruptions.
-            self._trajectory = append(
+            self._trajectory: State[T] = append(
                 _unsqueeze_time_dim(initial_state), self._trajectory
             )
 
         # Clear the internal trajectory so that we don't keep appending to it on subsequent simulate calls.
-        self.trajectory = self._trajectory
-        self._trajectory: State[T] = State()
+        self.trajectory: State[T] = self._trajectory
+        self._trajectory: State[T] = type(initial_state)()
 
         if self.is_traced:
             # This adds the trajectory to the trace so that it can be accessed later.
@@ -53,7 +53,13 @@ class LogTrajectory(Generic[T], pyro.poutine.messenger.Messenger):
 
     def _pyro_simulate_point(self, msg) -> None:
         # Turn a simulate that returns a state into a simulate that returns a trajectory at each of the logging_times
-        dynamics, initial_state, start_time, end_time = msg["args"]
+        dynamics: Dynamics[T] = msg["args"][0]
+        initial_state: State[T] = msg["args"][1]
+        start_time = msg["args"][2]
+        end_time = msg["args"][3]
+
+        if not self._trajectory:  # get type right
+            self._trajectory = type(initial_state)()
 
         filtered_timespan = self.times[
             (self.times > start_time) & (self.times <= end_time)
@@ -63,7 +69,7 @@ class LogTrajectory(Generic[T], pyro.poutine.messenger.Messenger):
         )
 
         with pyro.poutine.messenger.block_messengers(lambda m: m is self):
-            trajectory = simulate_trajectory(
+            trajectory: State[T] = simulate_trajectory(
                 dynamics, initial_state, timespan, **msg["kwargs"]
             )
 
@@ -74,7 +80,7 @@ class LogTrajectory(Generic[T], pyro.poutine.messenger.Messenger):
 
         if len(timespan) > 2:
             part_idx = IndexSet(**{idx_name: set(range(1, len(timespan) - 1))})
-            new_part = gather(trajectory, part_idx, name_to_dim=name_to_dim)
+            new_part: State[T] = gather(trajectory, part_idx, name_to_dim=name_to_dim)
             self._trajectory: State[T] = append(self._trajectory, new_part)
 
         final_idx = IndexSet(**{idx_name: {len(timespan) - 1}})

--- a/chirho/dynamical/internals/_utils.py
+++ b/chirho/dynamical/internals/_utils.py
@@ -1,3 +1,4 @@
+import collections.abc
 import dataclasses
 import functools
 import typing
@@ -17,7 +18,7 @@ def append(fst, rest: T) -> T:
     raise NotImplementedError(f"append not implemented for type {type(fst)}.")
 
 
-@append.register(dict)
+@append.register(collections.abc.Mapping)
 def _append_trajectory(traj1: State[T], traj2: State[T]) -> State[T]:
     if len(traj1.keys()) == 0:
         return traj2
@@ -30,10 +31,7 @@ def _append_trajectory(traj1: State[T], traj2: State[T]) -> State[T]:
             f"Trajectories must have the same keys to be appended, but got {traj1.keys()} and {traj2.keys()}."
         )
 
-    result: State[T] = State()
-    for k in traj1.keys():
-        result[k] = append(traj1[k], traj2[k])
-    return result
+    return type(traj1)(**{k: append(traj1[k], traj2[k]) for k in traj1.keys()})
 
 
 @append.register(torch.Tensor)
@@ -57,9 +55,9 @@ def _squeeze_time_dim(state_or_traj):
     )
 
 
-@_squeeze_time_dim.register(dict)
+@_squeeze_time_dim.register(collections.abc.Mapping)
 def _squeeze_time_dim_trajectory(traj: State[T]) -> State[T]:
-    return State(**{k: _squeeze_time_dim(traj[k]) for k in traj.keys()})
+    return type(traj)(**{k: _squeeze_time_dim(traj[k]) for k in traj.keys()})
 
 
 @_squeeze_time_dim.register(torch.Tensor)
@@ -74,9 +72,9 @@ def _unsqueeze_time_dim(state_or_traj):
     )
 
 
-@_unsqueeze_time_dim.register(dict)
+@_unsqueeze_time_dim.register(collections.abc.Mapping)
 def _unsqueeze_time_dim_state(state: State[T]) -> State[T]:
-    return State(**{k: _unsqueeze_time_dim(state[k]) for k in state.keys()})
+    return type(state)(**{k: _unsqueeze_time_dim(state[k]) for k in state.keys()})
 
 
 @_unsqueeze_time_dim.register(torch.Tensor)

--- a/chirho/dynamical/internals/backends/torchdiffeq.py
+++ b/chirho/dynamical/internals/backends/torchdiffeq.py
@@ -88,7 +88,7 @@ def _torchdiffeq_ode_simulate_inner(
             torch.cat((s, s[..., -1].unsqueeze(time_dim)), dim=time_dim) for s in solns
         )
 
-    return type(initial_state)(**zip(var_order, solns))
+    return type(initial_state)(**dict(zip(var_order, solns)))
 
 
 def _batched_odeint(

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -1,7 +1,5 @@
 import numbers
-import sys
-import typing
-from typing import Callable, Dict, Generic, TypeVar, Union
+from typing import Callable, Mapping, TypeVar, Union
 
 import pyro
 import torch
@@ -10,17 +8,7 @@ R = Union[numbers.Real, torch.Tensor]
 S = TypeVar("S")
 T = TypeVar("T")
 
-
-if typing.TYPE_CHECKING:
-    State = Dict[str, T]
-elif sys.version_info >= (3, 9):
-    State = dict
-else:
-
-    class State(Generic[T], Dict[str, T]):
-        pass
-
-
+State = Mapping[str, T]
 Dynamics = Callable[[State[T]], State[T]]
 
 

--- a/docs/source/dynamical_intro.ipynb
+++ b/docs/source/dynamical_intro.ipynb
@@ -190,7 +190,7 @@
     "        self.gamma = gamma\n",
     "\n",
     "    def forward(self, X: State[torch.Tensor]):\n",
-    "        dX = State()\n",
+    "        dX = dict()\n",
     "        dX[\"S\"] = -self.beta * X[\"S\"] * X[\"I\"]\n",
     "        dX[\"I\"] = self.beta * X[\"S\"] * X[\"I\"] - self.gamma * X[\"I\"]\n",
     "        dX[\"R\"] = self.gamma * X[\"I\"]\n",
@@ -229,7 +229,7 @@
    "outputs": [],
    "source": [
     "# Assume there is initially a population of 99 million people that are susceptible, 1 million infected, and 0 recovered\n",
-    "init_state = State(S=torch.tensor(99.0), I=torch.tensor(1.0), R=torch.tensor(0.0))\n",
+    "init_state = dict(S=torch.tensor(99.0), I=torch.tensor(1.0), R=torch.tensor(0.0))\n",
     "start_time = torch.tensor(0.0)\n",
     "end_time = torch.tensor(3.0)\n",
     "step_size = torch.tensor(0.1)\n",
@@ -257,7 +257,7 @@
     "with pyro.poutine.trace() as tr:\n",
     "    sir_observation_model(sir_obs_traj)\n",
     "\n",
-    "sir_data = State(**{k:tr.trace.nodes[k][\"value\"] for k in [\"I_obs\", \"R_obs\"]})"
+    "sir_data = dict(**{k:tr.trace.nodes[k][\"value\"] for k in [\"I_obs\", \"R_obs\"]})"
    ]
   },
   {
@@ -771,7 +771,7 @@
     "        return dX\n",
     "\n",
     "\n",
-    "init_state_lockdown = State(**init_state, l=torch.tensor(0.0))"
+    "init_state_lockdown = dict(**init_state, l=torch.tensor(0.0))"
    ]
   },
   {
@@ -800,8 +800,8 @@
     "    sir = bayesian_sir(SIRDynamicsLockdown)\n",
     "    with LogTrajectory(logging_times, is_traced=True) as lt:\n",
     "        with TorchDiffEq():\n",
-    "            with StaticIntervention(time=lockdown_start, intervention=State(l=lockdown_strength)):\n",
-    "                with StaticIntervention(time=lockdown_end, intervention=State(l=torch.tensor(0.0))):\n",
+    "            with StaticIntervention(time=lockdown_start, intervention=dict(l=lockdown_strength)):\n",
+    "                with StaticIntervention(time=lockdown_end, intervention=dict(l=torch.tensor(0.0))):\n",
     "                    simulate(sir, init_state, start_time, logging_times[-1])\n",
     "                    \n",
     "    return lt.trajectory"
@@ -1061,8 +1061,8 @@
     "    sir = bayesian_sir(SIRDynamicsLockdown)\n",
     "    with LogTrajectory(logging_times, is_traced=True) as lt:\n",
     "        with TorchDiffEq():\n",
-    "            with DynamicIntervention(event_fn=government_lockdown_policy(lockdown_trigger), intervention=State(l=lockdown_strength)):\n",
-    "                with DynamicIntervention(event_fn=government_lift_policy(lockdown_lift_trigger), intervention=State(l=torch.tensor(0.0))):\n",
+    "            with DynamicIntervention(event_fn=government_lockdown_policy(lockdown_trigger), intervention=dict(l=lockdown_strength)):\n",
+    "                with DynamicIntervention(event_fn=government_lift_policy(lockdown_lift_trigger), intervention=dict(l=torch.tensor(0.0))):\n",
     "                    simulate(sir, init_state, logging_times[0], logging_times[-1])\n",
     "    return lt.trajectory"
    ]
@@ -1078,8 +1078,8 @@
    },
    "outputs": [],
    "source": [
-    "lockdown_trigger = State(I=torch.tensor(30.0))\n",
-    "lockdown_lift_trigger = State(R=torch.tensor(20.0))\n",
+    "lockdown_trigger = dict(I=torch.tensor(30.0))\n",
+    "lockdown_lift_trigger = dict(R=torch.tensor(20.0))\n",
     "lockdown_strength = torch.tensor(0.9)  # reduces transmission rate by 90%\n",
     "\n",
     "true_dynamic_intervened_sir = pyro.condition(dynamic_intervened_sir, data={\"beta\": beta_true, \"gamma\": gamma_true})\n",
@@ -1193,8 +1193,8 @@
     "\n",
     "\n",
     "def uncertain_dynamic_intervened_sir(lockdown_strength, init_state, start_time, logging_times) -> State:\n",
-    "    lockdown_trigger = State(I=pyro.sample(\"lockdown_trigger\", dist.Uniform(lockdown_trigger_min, lockdown_trigger_max)))\n",
-    "    lockdown_lift_trigger = State(R=pyro.sample(\"lockdown_lift_trigger\", dist.Uniform(lockdown_lift_trigger_min, lockdown_lift_trigger_max)))\n",
+    "    lockdown_trigger = dict(I=pyro.sample(\"lockdown_trigger\", dist.Uniform(lockdown_trigger_min, lockdown_trigger_max)))\n",
+    "    lockdown_lift_trigger = dict(R=pyro.sample(\"lockdown_lift_trigger\", dist.Uniform(lockdown_lift_trigger_min, lockdown_lift_trigger_max)))\n",
     "    return dynamic_intervened_sir(lockdown_trigger, lockdown_lift_trigger, lockdown_strength, init_state, start_time, logging_times)"
    ]
   },

--- a/tests/dynamical/dynamical_fixtures.py
+++ b/tests/dynamical/dynamical_fixtures.py
@@ -24,7 +24,7 @@ class UnifiedFixtureDynamics(pyro.nn.PyroModule):
             self.gamma = pyro.param("gamma", torch.tensor(0.7), constraints.positive)
 
     def forward(self, X: State[torch.Tensor]):
-        dX: State[torch.Tensor] = State()
+        dX: State[torch.Tensor] = dict()
         beta = self.beta * (
             1.0 + 0.1 * torch.sin(0.1 * X["t"])
         )  # beta oscilates slowly in time.

--- a/tests/dynamical/test_dynamic_interventions.py
+++ b/tests/dynamical/test_dynamic_interventions.py
@@ -22,15 +22,15 @@ end_time = torch.tensor(10.0)
 logging_times = torch.linspace(start_time + 1, end_time - 2, 10)
 
 # Initial state of the system.
-init_state = State(S=torch.tensor(50.0), I=torch.tensor(3.0), R=torch.tensor(0.0))
+init_state = dict(S=torch.tensor(50.0), I=torch.tensor(3.0), R=torch.tensor(0.0))
 
 # State at which the dynamic intervention will trigger.
-trigger_state1 = State(R=torch.tensor(30.0))
-trigger_state2 = State(R=torch.tensor(50.0))
+trigger_state1 = dict(R=torch.tensor(30.0))
+trigger_state2 = dict(R=torch.tensor(50.0))
 
 # State we'll switch to when the dynamic intervention triggers.
-intervene_state1 = State(S=torch.tensor(50.0))
-intervene_state2 = State(S=torch.tensor(30.0))
+intervene_state1 = dict(S=torch.tensor(50.0))
+intervene_state2 = dict(S=torch.tensor(30.0))
 
 
 def get_state_reached_event_f(target_state: State[torch.tensor], event_dim: int = 0):
@@ -396,7 +396,7 @@ def test_split_twinworld_dynamic_matches_output(
 
 def test_grad_of_dynamic_intervention_event_f_params():
     def model(X: State[torch.Tensor]):
-        dX = State()
+        dX = dict()
         dX["x"] = torch.tensor(1.0)
         dX["z"] = X["dz"]
         dX["dz"] = torch.tensor(0.0)  # also a constant, this gets set by interventions.
@@ -407,13 +407,13 @@ def test_grad_of_dynamic_intervention_event_f_params():
 
     param = torch.nn.Parameter(torch.tensor(5.0))
     # Param has to be part of the state in order to take gradients with respect to it.
-    s0 = State(
+    s0 = dict(
         x=torch.tensor(0.0), z=torch.tensor(0.0), dz=torch.tensor(0.0), param=param
     )
 
     dynamic_intervention = DynamicIntervention(
         event_fn=lambda t, s: t - s["param"],
-        intervention=State(dz=torch.tensor(1.0)),
+        intervention=dict(dz=torch.tensor(1.0)),
     )
 
     # noinspection DuplicatedCode

--- a/tests/dynamical/test_handler_composition.py
+++ b/tests/dynamical/test_handler_composition.py
@@ -24,7 +24,7 @@ from tests.dynamical.dynamical_fixtures import (
 logger = logging.getLogger(__name__)
 
 # Global variables for tests
-init_state = State(S=torch.tensor(10.0), I=torch.tensor(1.0), R=torch.tensor(0.0))
+init_state = dict(S=torch.tensor(10.0), I=torch.tensor(1.0), R=torch.tensor(0.0))
 start_time = torch.tensor(0.0)
 end_time = torch.tensor(1.2)
 logging_times = torch.tensor([0.3, 0.6, 0.9])
@@ -39,7 +39,7 @@ landing_time = 0.3 + 1e-2
 
 ssd = torch.tensor(2.0)
 
-counterfactual = State(
+counterfactual = dict(
     S=lambda s: s - ssd,
     I=lambda i: i + ssd,
 )

--- a/tests/dynamical/test_log_trajectory.py
+++ b/tests/dynamical/test_log_trajectory.py
@@ -19,7 +19,7 @@ pyro.settings.set(module_local_params=True)
 logger = logging.getLogger(__name__)
 
 # Global variables for tests
-init_state = State(S=torch.tensor(1.0), I=torch.tensor(2.0), R=torch.tensor(3.3))
+init_state = dict(S=torch.tensor(1.0), I=torch.tensor(2.0), R=torch.tensor(3.3))
 start_time = torch.tensor(0.0)
 end_time = torch.tensor(4.0)
 logging_times = torch.tensor([1.0, 2.0, 3.0])
@@ -62,13 +62,13 @@ def test_logging_with_colliding_interruption():
 
 
 def test_trajectory_methods():
-    trajectory = State(S=torch.tensor([1.0, 2.0, 3.0]))
+    trajectory = dict(S=torch.tensor([1.0, 2.0, 3.0]))
     assert trajectory.keys() == frozenset({"S"})
 
 
 def test_append():
-    trajectory1 = State(S=torch.tensor([1.0, 2.0, 3.0]))
-    trajectory2 = State(S=torch.tensor([4.0, 5.0, 6.0]))
+    trajectory1 = dict(S=torch.tensor([1.0, 2.0, 3.0]))
+    trajectory2 = dict(S=torch.tensor([4.0, 5.0, 6.0]))
     trajectory = append(trajectory1, trajectory2)
     assert torch.allclose(
         trajectory["S"], torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
@@ -77,9 +77,9 @@ def test_append():
 
 def test_start_end_time_collisions():
     def dynamics(s: State) -> State:
-        return State(X=s["X"] * (1 - s["X"]))
+        return dict(X=s["X"] * (1 - s["X"]))
 
-    init_state = State(X=torch.tensor(0.5))
+    init_state = dict(X=torch.tensor(0.5))
     start_time, end_time = torch.tensor(0.0), torch.tensor(3.0)
 
     with TorchDiffEq():

--- a/tests/dynamical/test_noop_interruptions.py
+++ b/tests/dynamical/test_noop_interruptions.py
@@ -9,7 +9,7 @@ from chirho.dynamical.handlers import (
     StaticIntervention,
 )
 from chirho.dynamical.handlers.solver import TorchDiffEq
-from chirho.dynamical.ops import State, simulate
+from chirho.dynamical.ops import simulate
 
 from .dynamical_fixtures import UnifiedFixtureDynamics, check_states_match
 
@@ -19,15 +19,13 @@ logger = logging.getLogger(__name__)
 start_time = torch.tensor(1.0)
 end_time = torch.tensor(4.0)
 # Initial state of the system.
-init_state_values = State(
-    S=torch.tensor(10.0), I=torch.tensor(3.0), R=torch.tensor(1.0)
-)
+init_state_values = dict(S=torch.tensor(10.0), I=torch.tensor(3.0), R=torch.tensor(1.0))
 
 intervene_states = [
-    State(S=torch.tensor(11.0)),
-    State(I=torch.tensor(9.0)),
-    State(S=torch.tensor(10.0), R=torch.tensor(5.0)),
-    State(S=torch.tensor(20.0), I=torch.tensor(11.0), R=torch.tensor(4.0)),
+    dict(S=torch.tensor(11.0)),
+    dict(I=torch.tensor(9.0)),
+    dict(S=torch.tensor(10.0), R=torch.tensor(5.0)),
+    dict(S=torch.tensor(20.0), I=torch.tensor(11.0), R=torch.tensor(4.0)),
 ]
 
 

--- a/tests/dynamical/test_solver.py
+++ b/tests/dynamical/test_solver.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 from chirho.dynamical.handlers.solver import TorchDiffEq
-from chirho.dynamical.ops import State, simulate
+from chirho.dynamical.ops import simulate
 
 from .dynamical_fixtures import bayes_sir_model
 
@@ -14,7 +14,7 @@ pyro.settings.set(module_local_params=True)
 logger = logging.getLogger(__name__)
 
 # Global variables for tests
-init_state = State(S=torch.tensor(1.0), I=torch.tensor(2.0), R=torch.tensor(3.3))
+init_state = dict(S=torch.tensor(1.0), I=torch.tensor(2.0), R=torch.tensor(3.3))
 start_time = torch.tensor(0.0)
 end_time = torch.tensor(4.0)
 

--- a/tests/dynamical/test_static_interventions.py
+++ b/tests/dynamical/test_static_interventions.py
@@ -9,7 +9,7 @@ from chirho.counterfactual.handlers import (
 )
 from chirho.dynamical.handlers import LogTrajectory, StaticIntervention
 from chirho.dynamical.handlers.solver import TorchDiffEq
-from chirho.dynamical.ops import State, simulate
+from chirho.dynamical.ops import simulate
 from chirho.indexed.ops import IndexSet, gather, indices_of
 from chirho.interventional.ops import intervene
 
@@ -27,15 +27,13 @@ end_time = torch.tensor(10.0)
 logging_times = torch.linspace(start_time + 0.01, end_time - 2, 5)
 
 # Initial state of the system.
-init_state_values = State(
-    S=torch.tensor(10.0), I=torch.tensor(3.0), R=torch.tensor(1.0)
-)
+init_state_values = dict(S=torch.tensor(10.0), I=torch.tensor(3.0), R=torch.tensor(1.0))
 
 # Large interventions that will make a difference.
 intervene_states = [
-    State(I=torch.tensor(50.0)),
-    State(S=torch.tensor(50.0), R=torch.tensor(50.0)),
-    State(S=torch.tensor(50.0), I=torch.tensor(50.0), R=torch.tensor(50.0)),
+    dict(I=torch.tensor(50.0)),
+    dict(S=torch.tensor(50.0), R=torch.tensor(50.0)),
+    dict(S=torch.tensor(50.0), I=torch.tensor(50.0), R=torch.tensor(50.0)),
 ]
 
 # Define intervention times before all tspan values.

--- a/tests/dynamical/test_static_observation.py
+++ b/tests/dynamical/test_static_observation.py
@@ -26,7 +26,7 @@ pyro.settings.set(module_local_params=True)
 logger = logging.getLogger(__name__)
 
 # Global variables for tests
-init_state = State(S=torch.tensor(1.0), I=torch.tensor(2.0), R=torch.tensor(3.3))
+init_state = dict(S=torch.tensor(1.0), I=torch.tensor(2.0), R=torch.tensor(3.3))
 start_time = torch.tensor(0.0)
 end_time = torch.tensor(4.0)
 logging_times = torch.tensor([1.0, 2.0, 3.0])

--- a/tests/dynamical/test_validate_dynamics.py
+++ b/tests/dynamical/test_validate_dynamics.py
@@ -13,7 +13,7 @@ pyro.settings.set(module_local_params=True)
 logger = logging.getLogger(__name__)
 
 # Global variables for tests
-init_state = State(S=torch.tensor(1.0))
+init_state = dict(S=torch.tensor(1.0))
 start_time = torch.tensor(0.0)
 end_time = torch.tensor(4.0)
 
@@ -24,7 +24,7 @@ def valid_diff(state: State) -> State:
 
 def invalid_diff(state: State) -> State:
     pyro.sample("x", pyro.distributions.Normal(0.0, 1.0))
-    return State(S=(state["S"]))
+    return dict(S=(state["S"]))
 
 
 def test_validate_dynamics_torchdiffeq():


### PR DESCRIPTION
Addresses #350 

This refactoring PR makes the interface type `chirho.dynamical.ops.State` into an alias for the generic protocol `typing.Mapping[str, T]`, rather than a concrete `dict` type.