### PR TITLE
Add dynamical requirements to test requirements

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[test,dynamical]
+          pip install .[test]
 
       - name: Lint
         run: ./scripts/lint.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           sudo apt install -y pandoc
           python -m pip install --upgrade pip
-          pip install .[test,dynamical]
+          pip install .[test]
 
       - name: Test
         shell: bash

--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -39,7 +39,7 @@ jobs:
         - name: Install Python packages from requirements.txt
           run: |
             pip install --upgrade pip
-            pip install -e .[test,dynamical]
+            pip install -e .[test]
     
         - name: Run Notebook Test
           run: | 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     extras_require={
         "dynamical": DYNAMICAL_REQUIRE,
         "extras": EXTRAS_REQUIRE,
-        "test": EXTRAS_REQUIRE
+        "test": EXTRAS_REQUIRE + DYNAMICAL_REQUIRE
         + [
             "pytest",
             "pytest-cov",


### PR DESCRIPTION
This PR addresses a comment in #425 that installing the `test` requirements should install all dependencies required to run tests.