### PR TITLE
Add a generic on() operation to dynamical

### DIFF
--- a/chirho/dynamical/handlers/interruption.py
+++ b/chirho/dynamical/handlers/interruption.py
@@ -18,6 +18,24 @@ T = TypeVar("T")
 
 
 class ZeroEvent(Generic[T]):
+    """
+    Class for creating event functions for use with :func:`~chirho.dynamical.ops.on`
+    that trigger when a given scalar-valued function approaches and crosses ``0.``
+
+    For example, to define an event handler that calls :func:`~chirho.interventional.ops.intervene`
+    when the state variable `x` exceeds 10.0, we could use the following::
+
+        @on(ZeroEvent(lambda time, state: state["x"] - 10.0)
+        def callback(dynamics: Dynamics[T], state: State[T]) -> Tuple[Dynamics[T], State[T]]:
+            return dynamics, intervene(state, {"x": 0.0})
+
+    .. note:: some backends, such as :class:`~chirho.dynamical.handlers.solver.TorchDiffEq`,
+        only support event handler predicates specified via :class:`~ZeroEvent` ,
+        not via arbitrary boolean-valued functions of the state.
+
+    :param event_fn: A function that approaches and crosses 0.0 at the moment the event should be triggered.
+    """
+
     event_fn: Callable[[R, State[T]], R]
 
     def __init__(self, event_fn: Callable[[R, State[T]], R]):
@@ -29,6 +47,20 @@ class ZeroEvent(Generic[T]):
 
 
 class StaticEvent(Generic[T], ZeroEvent[T]):
+    """
+    Class for creating event functions for use with :func:`~chirho.dynamical.ops.on`
+    that trigger at a specified time.
+
+    For example, to define an event handler that calls :func:`~chirho.interventional.ops.intervene`
+    at time 10.0, we could use the following::
+
+        @on(StaticEvent(10.0))
+        def callback(dynamics: Dynamics[T], state: State[T]) -> Tuple[Dynamics[T], State[T]]:
+            return dynamics, intervene(state, {"x": 0.0})
+
+    :param time: The time at which the event should be triggered.
+    """
+
     time: torch.Tensor
     event_fn: Callable[[R, State[T]], R]
 

--- a/chirho/dynamical/handlers/interruption.py
+++ b/chirho/dynamical/handlers/interruption.py
@@ -50,6 +50,7 @@ def StaticInterruption(time: R):
 
     :param time: The time at which the simulation will be interrupted.
     """
+
     @on(StaticEvent(time))
     def callback(
         dynamics: Dynamics[T], state: State[T]
@@ -84,6 +85,7 @@ def StaticObservation(time: R, observation: Observation[State[T]]):
     :param time: The time at which the observation is made.
     :param observation: The observation noise model to apply to the state at the given time. Can be conditioned on data.
     """
+
     @on(StaticEvent(time))
     def callback(
         dynamics: Dynamics[T], state: State[T]
@@ -115,6 +117,7 @@ def StaticIntervention(time: R, intervention: Intervention[State[T]]):
         supported by that function. This includes state dependent interventions specified by a function, such as
         `lambda state: {"x": state["x"] + 1.0}`.
     """
+
     @on(StaticEvent(time))
     def callback(
         dynamics: Dynamics[T], state: State[T]
@@ -130,6 +133,7 @@ def DynamicInterruption(event_fn: Callable[[R, State[T]], R]):
         This can be designed to trigger when the current state is "close enough" to some trigger state, or when an
         element of the state exceeds some threshold, etc. It takes both the current time and current state.
     """
+
     @on(ZeroEvent(event_fn))
     def callback(
         dynamics: Dynamics[T], state: State[T]
@@ -156,6 +160,7 @@ def DynamicIntervention(
         supported by that function. This includes state dependent interventions specified by a function, such as
         `lambda state: {"x": state["x"] + 1.0}`.
     """
+
     @on(ZeroEvent(event_fn))
     def callback(
         dynamics: Dynamics[T], state: State[T]

--- a/chirho/dynamical/internals/solver.py
+++ b/chirho/dynamical/internals/solver.py
@@ -87,7 +87,10 @@ class Solver(Generic[T], pyro.poutine.messenger.Messenger):
                         "This interruption will have no effect.",
                         UserWarning,
                     )
-                elif isinstance(h.predicate, StaticEvent) and h.predicate.time < start_time:
+                elif (
+                    isinstance(h.predicate, StaticEvent)
+                    and h.predicate.time < start_time
+                ):
                     raise ValueError(
                         f"{Interruption.__name__} {h} with time {h.predicate.time} "
                         f"occurred before the start of the timespan ({start_time}, {end_time})."

--- a/chirho/dynamical/internals/solver.py
+++ b/chirho/dynamical/internals/solver.py
@@ -80,21 +80,21 @@ class Solver(Generic[T], pyro.poutine.messenger.Messenger):
 
         while start_time < end_time:
             for h in get_new_interruptions():
-                if isinstance(h.predicate, StaticEvent):
-                    if h.predicate.time > end_time:
-                        warnings.warn(
-                            f"{Interruption.__name__} {h} with time={h.predicate.time} "
-                            f"occurred after the end of the timespan ({start_time}, {end_time})."
-                            "This interruption will have no effect.",
-                            UserWarning,
-                        )
-                    elif h.predicate.time < start_time:
-                        raise ValueError(
-                            f"{Interruption.__name__} {h} with time {h.predicate.time} "
-                            f"occurred before the start of the timespan ({start_time}, {end_time})."
-                            "This interruption will have no effect."
-                        )
-                heapq.heappush(all_interruptions, self._prioritize_interruption(h))
+                if isinstance(h.predicate, StaticEvent) and h.predicate.time > end_time:
+                    warnings.warn(
+                        f"{Interruption.__name__} {h} with time={h.predicate.time} "
+                        f"occurred after the end of the timespan ({start_time}, {end_time})."
+                        "This interruption will have no effect.",
+                        UserWarning,
+                    )
+                elif isinstance(h.predicate, StaticEvent) and h.predicate.time < start_time:
+                    raise ValueError(
+                        f"{Interruption.__name__} {h} with time {h.predicate.time} "
+                        f"occurred before the start of the timespan ({start_time}, {end_time})."
+                        "This interruption will have no effect."
+                    )
+                else:
+                    heapq.heappush(all_interruptions, self._prioritize_interruption(h))
 
             possible_interruptions: List[Interruption[T]] = []
             while all_interruptions:

--- a/chirho/dynamical/internals/solver.py
+++ b/chirho/dynamical/internals/solver.py
@@ -164,13 +164,13 @@ def simulate_trajectory(
 
 @pyro.poutine.runtime.effectful(type="simulate_to_interruption")
 def simulate_to_interruption(
-    interruption_stack: List[Interruption],
+    interruption_stack: List[Interruption[T]],
     dynamics: Dynamics[T],
     start_state: State[T],
     start_time: R,
     end_time: R,
     **kwargs,
-) -> Tuple[State[T], R, Optional[Interruption]]:
+) -> Tuple[State[T], R, Optional[Interruption[T]]]:
     """
     Simulate a dynamical system until the next interruption.
 

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -78,8 +78,9 @@ def on(
         ...
         >>> assert xf < 0
 
-    .. warning:: ``on`` is a so-called "shallow" effect handler that only handles the first :func:`~chirho.dynamical.ops.simulate`
-        call within its context, and its ``callback`` can be triggered at most once.
+    .. warning:: ``on`` is a so-called "shallow" effect handler that only handles
+        the first :func:`~chirho.dynamical.ops.simulate`call within its context,
+        and its ``callback`` can be triggered at most once.
 
     .. warning:: some backends may not support interruptions via arbitrary predicates, and may only support
         interruptions that include additional information such as a statically known time at which to activate.

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -1,21 +1,10 @@
-import contextlib
 import numbers
-from typing import (
-    Callable,
-    Concatenate,
-    Mapping,
-    Optional,
-    ParamSpec,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from typing import Callable, Mapping, Optional, Tuple, TypeVar, Union
 
 import pyro
 import torch
 
 R = Union[numbers.Real, torch.Tensor]
-P = ParamSpec("P")
 S = TypeVar("S")
 T = TypeVar("T")
 

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -49,7 +49,15 @@ def on(
     ] = None,
 ):
     if callback is None:
-        return functools.partial(on, predicate)
+
+        def _on(
+            callback: Callable[
+                Concatenate[Dynamics[T], State[T], P], Tuple[Dynamics[T], State[T]]
+            ]
+        ):
+            return on(predicate, callback)
+
+        return _on
 
     from chirho.dynamical.internals.solver import Interruption
 

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -1,5 +1,4 @@
 import contextlib
-import functools
 import numbers
 from typing import (
     Callable,
@@ -43,17 +42,15 @@ def simulate(
 
 
 def on(
-    predicate: Callable[Concatenate[State[T], P], bool],
+    predicate: Callable[[State[T]], bool],
     callback: Optional[
-        Callable[Concatenate[Dynamics[T], State[T], P], Tuple[Dynamics[T], State[T]]]
+        Callable[[Dynamics[T], State[T]], Tuple[Dynamics[T], State[T]]]
     ] = None,
 ):
     if callback is None:
 
         def _on(
-            callback: Callable[
-                Concatenate[Dynamics[T], State[T], P], Tuple[Dynamics[T], State[T]]
-            ]
+            callback: Callable[[Dynamics[T], State[T]], Tuple[Dynamics[T], State[T]]]
         ):
             return on(predicate, callback)
 
@@ -61,15 +58,4 @@ def on(
 
     from chirho.dynamical.internals.solver import Interruption
 
-    @contextlib.contextmanager
-    def cm(*args: P.args, **kwargs: P.kwargs):
-        predicate_: Callable[[State[T]], bool] = lambda state: predicate(
-            state, *args, **kwargs
-        )
-        callback_: Callable[
-            [Dynamics[T], State[T]], Tuple[Dynamics[T], State[T]]
-        ] = lambda dynamics, state: callback(dynamics, state, *args, **kwargs)
-        with Interruption(predicate_, callback_):
-            yield
-
-    return cm
+    return Interruption(predicate, callback)


### PR DESCRIPTION
This refactoring PR adds a generic operation `chirho.dynamical.ops.on` for creating interruptions and rewrites `chirho.dynamical.handlers.interruptions` in terms of `on`.