### PR TITLE
add `random intervention` and a test thereof

### DIFF
--- a/chirho/explainable/handlers/__init__.py
+++ b/chirho/explainable/handlers/__init__.py
@@ -1,2 +1,3 @@
+from .alternatives import random_intervention  # noqa: F401
 from .preemptions import Preemptions  # noqa: F401
 from .split_subsets import SplitSubsets, undo_split  # noqa: F401

--- a/chirho/explainable/handlers/alternatives.py
+++ b/chirho/explainable/handlers/alternatives.py
@@ -1,0 +1,44 @@
+from typing import Callable, TypeVar
+
+import pyro
+import torch
+
+from chirho.explainable.internals import uniform_proposal
+
+S = TypeVar("S")
+T = TypeVar("T")
+
+
+def random_intervention(
+    support: pyro.distributions.constraints.Constraint,
+    name: str,
+) -> Callable[[torch.Tensor], torch.Tensor]:
+    """
+    Creates a random-valued intervention for a single sample site, determined by
+    by the distribution support, and site name.
+
+    :param support: The support constraint for the sample site.
+    :param name: The name of the auxiliary sample site.
+
+    :return: A function that takes a ``torch.Tensor`` as input
+        and returns a random sample over the pre-specified support of the same
+        event shape as the input tensor.
+
+    Example::
+
+        >>> support = pyro.distributions.constraints.real
+        >>> intervention_fn = random_intervention(support, name="random_value")
+        >>> with chirho.interventional.handlers.do(actions={"x": intervention_fn}):
+        ...   x = pyro.deterministic("x", torch.tensor(2.))
+        >>> assert x != 2
+    """
+
+    def _random_intervention(value: torch.Tensor) -> torch.Tensor:
+        event_shape = value.shape[len(value.shape) - support.event_dim :]
+        proposal_dist = uniform_proposal(
+            support,
+            event_shape=event_shape,
+        )
+        return pyro.sample(name, proposal_dist)
+
+    return _random_intervention

--- a/chirho/explainable/internals/__init__.py
+++ b/chirho/explainable/internals/__init__.py
@@ -1,0 +1,1 @@
+from .defaults import uniform_proposal  # noqa: F401

--- a/tests/explainable/test_alternatives.py
+++ b/tests/explainable/test_alternatives.py
@@ -1,0 +1,31 @@
+import pyro
+import pytest
+import torch
+
+from chirho.explainable.handlers import random_intervention
+from chirho.interventional.ops import intervene
+
+SUPPORT_CASES = [
+    pyro.distributions.constraints.real,
+    pyro.distributions.constraints.boolean,
+    pyro.distributions.constraints.positive,
+    pyro.distributions.constraints.interval(0, 10),
+    pyro.distributions.constraints.interval(-5, 5),
+    pyro.distributions.constraints.integer_interval(0, 2),
+    pyro.distributions.constraints.integer_interval(0, 100),
+]
+
+
+@pytest.mark.parametrize("support", SUPPORT_CASES)
+@pytest.mark.parametrize("event_shape", [(), (3,), (3, 2)], ids=str)
+def test_random_intervention(support, event_shape):
+    if event_shape:
+        support = pyro.distributions.constraints.independent(support, len(event_shape))
+
+    obs_value = torch.randn(event_shape)
+    intervention = random_intervention(support, "samples")
+
+    with pyro.plate("draws", 10):
+        samples = intervene(obs_value, intervention)
+
+    assert torch.all(support.check(samples))


### PR DESCRIPTION
Part of refactoring the explainable reasoning functionality into a separate module. Resolves #443 .