### PR TITLE
Propapagate type aliases through sphinx

### DIFF
--- a/chirho/counterfactual/handlers/counterfactual.py
+++ b/chirho/counterfactual/handlers/counterfactual.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict, Generic, Mapping, TypeVar
 
 import pyro

--- a/chirho/counterfactual/handlers/explanation.py
+++ b/chirho/counterfactual/handlers/explanation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections.abc
 import contextlib
 import functools

--- a/chirho/counterfactual/ops.py
+++ b/chirho/counterfactual/ops.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 from typing import Optional, Tuple, TypeVar
 

--- a/chirho/dynamical/handlers/interruption.py
+++ b/chirho/dynamical/handlers/interruption.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numbers
 import typing
 from typing import Callable, Generic, Tuple, TypeVar, Union

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numbers
 from typing import Callable, Mapping, Optional, Tuple, TypeVar, Union
 

--- a/chirho/interventional/handlers.py
+++ b/chirho/interventional/handlers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import functools
 from typing import Callable, Dict, Generic, Hashable, Mapping, Optional, TypeVar

--- a/chirho/interventional/ops.py
+++ b/chirho/interventional/ops.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 from typing import Callable, Hashable, Mapping, Optional, Tuple, TypeVar, Union
 

--- a/chirho/observational/handlers/condition.py
+++ b/chirho/observational/handlers/condition.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable, Generic, Hashable, Mapping, TypeVar, Union
 
 import pyro

--- a/chirho/observational/handlers/soft_conditioning.py
+++ b/chirho/observational/handlers/soft_conditioning.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import operator
 from typing import Callable, Literal, Optional, Protocol, TypedDict, TypeVar, Union

--- a/chirho/observational/internals.py
+++ b/chirho/observational/internals.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Mapping, Optional, TypeVar
 
 import pyro

--- a/chirho/observational/ops.py
+++ b/chirho/observational/ops.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 from typing import Callable, Hashable, Mapping, Optional, TypeVar, Union
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,6 +32,10 @@ autodoc_type_aliases = {
     'AtomicIntervention': 'AtomicIntervention',
     'CompoundIntervention': 'CompoundIntervention',
     'Intervention': 'Intervention',
+    'AtomicObservation': 'AtomicObservation',
+    'CompoundObservation': 'CompoundObservation',
+    'Observation': 'Observation',
+    'Kernel': 'Kernel',
 
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,6 +29,10 @@ autodoc_type_aliases = {
     'R': 'R',
     'State': 'State',
     'Dynamics': 'Dynamics',
+    'AtomicIntervention': 'AtomicIntervention',
+    'CompoundIntervention': 'CompoundIntervention',
+    'Intervention': 'Intervention',
+
 }
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,6 +23,14 @@ copyright = '2023, Basis'
 author = 'Basis'
 
 
+# -- Type hints configuration ------------------------------------------------
+
+autodoc_type_aliases = {
+    'R': 'R',
+    'State': 'State',
+    'Dynamics': 'Dynamics',
+}
+
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be


### PR DESCRIPTION
Previously, type aliases used throughout the repo would be expressed our sphinx documentation completely unpacked with their full definition. For example, 

<img width="953" alt="Screenshot 2023-12-09 at 10 33 14 AM" src="https://github.com/BasisResearch/chirho/assets/13202375/c5d4b185-d435-488a-9f50-ad8d20c36de9">


This is exceptionally verbose. Instead, we would like the sphinx documentation to render the type aliases themselves. This PR addresses this problem by adding type aliases manually to the sphinx configuration, and then adding `from __future__ import annotations` throughout. As a result, the rendered docs now look like the following:

<img width="953" alt="Screenshot 2023-12-09 at 10 34 49 AM" src="https://github.com/BasisResearch/chirho/assets/13202375/a6406c8c-9f59-426d-9888-ca8b26dc536f">

Thanks to @azane for co-exploring what led to this solution.