### PR TITLE
explainable documentation update

### DIFF
--- a/chirho/explainable/handlers/explanation.py
+++ b/chirho/explainable/handlers/explanation.py
@@ -45,7 +45,7 @@ def SearchForExplanation(
         Unless alternative interventions are provided, \
         counterfactual values are uniformly sampled for each antecedent node \
         using :func:`~chirho.explainable.internals.uniform_proposal` \
-        given its support as a :class:`~pyro.distributions.constraints.Constraint` .
+        given its support as a :class:`~pyro.distributions.constraints.Constraint`.
 
       2. These interventions are randomly :func:`~chirho.explainable.ops.preempt`-ed \
         using :func:`~chirho.explainable.handlers.undo_split` \

--- a/chirho/explainable/handlers/explanation.py
+++ b/chirho/explainable/handlers/explanation.py
@@ -44,15 +44,15 @@ def SearchForExplanation(
         using :func:`~chirho.counterfactual.ops.split` . \
         Unless alternative interventions are provided, \
         counterfactual values are uniformly sampled for each antecedent node \
-        using :func:`~chirho.counterfactual.handlers.explanation.uniform_proposal` \
+        using :func:`~chirho.explainable.internals.uniform_proposal` \
         given its support as a :class:`~pyro.distributions.constraints.Constraint` .
 
-      2. These interventions are randomly :func:`~chirho.counterfactual.ops.preempt`-ed \
-        using :func:`~chirho.counterfactual.handlers.explanation.undo_split` \
-        by a :func:`~chirho.counterfactual.handlers.explanation.SearchForCause` handler.
+      2. These interventions are randomly :func:`~chirho.explainable.ops.preempt`-ed \
+        using :func:`~chirho.explainable.handlers.undo_split` \
+        by a :func:`~chirho.explainable.handlers.SplitSubsets` handler.
 
-      3. The witness nodes are randomly :func:`~chirho.counterfactual.ops.preempt`-ed \
-        to be kept at the values given in ``witnesses`` .
+      3. The witness nodes are randomly :func:`~chirho.explainable.ops.preempt`-ed \
+        to be kept at the values given in ``witnesses``.
 
       4. A :func:`~pyro.factor` node is added tracking whether the consequent nodes differ \
         between the factual and counterfactual worlds.

--- a/chirho/explainable/handlers/preemptions.py
+++ b/chirho/explainable/handlers/preemptions.py
@@ -12,14 +12,14 @@ T = TypeVar("T")
 
 class Preemptions(Generic[T], pyro.poutine.messenger.Messenger):
     """
-    Effect handler that applies the operation :func:`~chirho.counterfactual.ops.preempt`
+    Effect handler that applies the operation :func:`~chirho.explainable.ops.preempt`
     to sample sites in a probabilistic program,
     similar to the handler :func:`~chirho.observational.handlers.condition`
     for :func:`~chirho.observational.ops.observe` .
     or the handler :func:`~chirho.interventional.handlers.do`
     for :func:`~chirho.interventional.ops.intervene` .
 
-    See the documentation for :func:`~chirho.counterfactual.ops.preempt` for more details.
+    See the documentation for :func:`~chirho.explainable.ops.preempt` for more details.
 
     This handler introduces an auxiliary discrete random variable at each preempted sample site
     whose name is the name of the sample site prefixed by ``prefix``, and

--- a/chirho/explainable/handlers/split_subsets.py
+++ b/chirho/explainable/handlers/split_subsets.py
@@ -15,7 +15,7 @@ def undo_split(antecedents: Iterable[str] = [], event_dim: int = 0) -> Callable[
     """
     A helper function that undoes an upstream :func:`~chirho.counterfactual.ops.split` operation,
     meant to be used to create arguments to pass to :func:`~chirho.interventional.ops.intervene` ,
-    :func:`~chirho.counterfactual.ops.split`  or :func:`~chirho.counterfactual.ops.preempt`.
+    :func:`~chirho.counterfactual.ops.split`  or :func:`~chirho.explainable.ops.preempt`.
     Works by gathering the factual value and scattering it back into two alternative cases.
 
     :param antecedents: A list of upstream intervened sites which induced the :func:`split` to be reversed.
@@ -61,7 +61,7 @@ def SplitSubsets(
     On each run, nodes listed in `actions` are randomly selected and intervened on with probability `.5 + bias`
     (that is, preempted with probability `.5-bias`). The sampling is achieved by adding stochastic binary preemption
     nodes associated with intervention candidates. If a given preemption node has value `0`, the corresponding
-    intervention is executed. See tests in `tests/counterfactual/test_handlers_explanation.py` for examples.
+    intervention is executed. See tests in `tests/explainable/test_split_subsets.py` for examples.
 
     :param actions: A mapping of sites to interventions.
     :param bias: The scalar bias towards not intervening. Must be between -0.5 and 0.5, defaults to 0.0.

--- a/chirho/explainable/internals/defaults.py
+++ b/chirho/explainable/internals/defaults.py
@@ -18,7 +18,7 @@ def uniform_proposal(
     support. The choice of distribution depends on the type of support provided.
 
     - If the support is `real`, it creates a wide Normal distribution
-      and standard deviation, defaulting to (0,100).
+      and standard deviation, defaulting to (0,10).
     - If the support is `boolean`, it creates a Bernoulli distribution with a fixed logit of 0,
       corresponding to success probability .5.
     - If the support is an `interval`, the transformed distribution is centered around the


### PR DESCRIPTION
Docstring contained obsolete references to functions which migrated. These have now been revised. 

explainable
├─ ops.py
│  ├─  preempt                  # dostring refences outside of `explainable` were correct.     
│  └─  consequent_differs       # no references to functions in docstring, no changes needed. 
├─ internals
│  └─  defaults.py
│  	  └─ uniform_proposal       # no references to functions in docstring, no changes needed.  
├─ handlers
│  ├─ preemptions.py
│  │  └─ Preemptions            # docstrings updated 
│  ├─ split_subsets.py
│  │  ├─ undo_splits            # docstring updated
│  │  └─ SplitSubsets   		# no references to functions in docstring, reference to a test file changed.
│  ├─ alternatives.py
│  │  └─ random_intervention    # no references to functions in docstring, no changes needed.
│  └─ explanation.py
│     └─ SearchForExplanation   # references revised