### PR TITLE
Remove explainable references from chirho.counterfactual

### DIFF
--- a/chirho/counterfactual/handlers/counterfactual.py
+++ b/chirho/counterfactual/handlers/counterfactual.py
@@ -22,10 +22,6 @@ class BaseCounterfactualMessenger(FactualConditioningMessenger):
     :func:`~chirho.interventional.ops.intervene` by instantiating the primitive operation
     :func:`~chirho.counterfactual.ops.split`, which is then subsequently handled by subclasses
     such as :class:`~chirho.counterfactual.handlers.counterfactual.MultiWorldCounterfactual`.
-
-    In addition, :class:`~chirho.counterfactual.handlers.counterfactual.BaseCounterfactualMessenger`
-    handles :func:`~chirho.counterfactual.ops.preempt` operations by introducing an auxiliary categorical
-    variable at each of the preempted addresses.
     """
 
     @staticmethod

--- a/docs/source/counterfactual.rst
+++ b/docs/source/counterfactual.rst
@@ -31,10 +31,6 @@ Handlers
    :members:
    :undoc-members:
 
-.. automodule:: chirho.counterfactual.handlers.explanation
-   :members:
-   :undoc-members:
-
 Internals
 ---------
 


### PR DESCRIPTION
This PR follows up on #457 by removing references within the documentation of `chirho.counterfactual` to functionality that is now part of `chirho.explainable`.