### PR TITLE
Performance improvements for `chirho.robust`

### DIFF
--- a/chirho/robust/internals/linearize.py
+++ b/chirho/robust/internals/linearize.py
@@ -180,7 +180,7 @@ def linearize(
 
     def _fn(
         points: Point[T],
-        pointwise_influence: bool = False,
+        pointwise_influence: bool = True,
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> ParamDict:

--- a/chirho/robust/internals/linearize.py
+++ b/chirho/robust/internals/linearize.py
@@ -52,8 +52,8 @@ def _flat_conjugate_gradient_solve(
     else:
         cg_iters = min(cg_iters, b.shape[1])
 
-    def _batched_dot(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
-        return (a * b).sum(axis=-1)
+    def _batched_dot(x1: torch.Tensor, x2: torch.Tensor) -> torch.Tensor:
+        return (x1 * x2).sum(axis=-1)  # type: ignore
 
     def _batched_product(a: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
         return a.unsqueeze(0).t() * B

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -182,11 +182,15 @@ class PointLogPredictiveLikelihood(NMCLogPredictiveLikelihood):
         log_like_trace.compute_log_prob(lambda name, site: name in data.keys())
         log_prob_at_datapoints = torch.zeros(num_monte_carlo)
         for site_name in data.keys():
-            # Sum probabilities over all dimensions except first batch dimension
-            dims_to_sum = list(
-                range(1, log_like_trace.nodes[site_name]["log_prob"].dim())
-            )
-            log_prob_at_datapoints += log_like_trace.nodes[site_name]["log_prob"].sum(
-                dim=dims_to_sum
-            )
+            if log_like_trace.nodes[site_name]["log_prob"].dim() > 1:
+                # Sum probabilities over all dimensions except first batch dimension
+                dims_to_sum = list(
+                    range(1, log_like_trace.nodes[site_name]["log_prob"].dim())
+                )
+                log_prob_at_datapoints += log_like_trace.nodes[site_name][
+                    "log_prob"
+                ].sum(dim=dims_to_sum)
+            else:
+                log_prob_at_datapoints += log_like_trace.nodes[site_name]["log_prob"]
+
         return log_prob_at_datapoints

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -182,8 +182,11 @@ class PointLogPredictiveLikelihood(NMCLogPredictiveLikelihood):
         log_like_trace.compute_log_prob(lambda name, site: name in data.keys())
         log_prob_at_datapoints = torch.zeros(num_monte_carlo)
         for site_name in data.keys():
-            site_prob = log_like_trace.nodes[site_name]["log_prob"]
             # Sum probabilities over all dimensions except first batch dimension
-            dims_to_sum = list(range(1, site_prob.dim()))
-            log_prob_at_datapoints += site_prob.sum(dim=dims_to_sum)
+            dims_to_sum = list(
+                range(1, log_like_trace.nodes[site_name]["log_prob"].dim())
+            )
+            log_prob_at_datapoints += log_like_trace.nodes[site_name]["log_prob"].sum(
+                dim=dims_to_sum
+            )
         return log_prob_at_datapoints

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -179,7 +179,7 @@ class PointLogPredictiveLikelihood(NMCLogPredictiveLikelihood):
 
         # Compute log likelihood at each monte carlo sample
         log_like_trace = pyro.poutine.trace(batched_model).get_trace(*args, **kwargs)
-        log_like_trace.compute_log_prob()
+        log_like_trace.compute_log_prob(lambda name, site: name in data.keys())
         log_prob_at_datapoints = torch.zeros(num_monte_carlo)
         for site_name in data.keys():
             site_prob = log_like_trace.nodes[site_name]["log_prob"]

--- a/chirho/robust/internals/utils.py
+++ b/chirho/robust/internals/utils.py
@@ -23,11 +23,13 @@ def make_flatten_unflatten(
 
 @make_flatten_unflatten.register(torch.Tensor)
 def _make_flatten_unflatten_tensor(v: torch.Tensor):
+    batch_size = v.shape[0]
+
     def flatten(v: torch.Tensor) -> torch.Tensor:
         r"""
         Flatten a tensor into a single vector.
         """
-        return v.flatten()
+        return v.reshape((batch_size, -1))
 
     def unflatten(x: torch.Tensor) -> torch.Tensor:
         r"""

--- a/chirho/robust/ops.py
+++ b/chirho/robust/ops.py
@@ -39,8 +39,15 @@ def influence_fn(
     target_params, func_target = make_functional_call(target)
 
     @functools.wraps(target)
-    def _fn(points: Point[T], *args: P.args, **kwargs: P.kwargs) -> S:
-        param_eif = linearized(points, *args, **kwargs)
+    def _fn(
+        points: Point[T],
+        pointwise_influence: bool = False,
+        *args: P.args,
+        **kwargs: P.kwargs
+    ) -> S:
+        param_eif = linearized(
+            points, pointwise_influence=pointwise_influence, *args, **kwargs
+        )
         return torch.vmap(
             lambda d: torch.func.jvp(
                 lambda p: func_target(p, *args, **kwargs), (target_params,), (d,)

--- a/chirho/robust/ops.py
+++ b/chirho/robust/ops.py
@@ -20,7 +20,7 @@ def influence_fn(
     guide: Callable[P, Any],
     functional: Optional[Functional[P, S]] = None,
     **linearize_kwargs
-) -> Callable[Concatenate[Point[T], P], S]:
+) -> Callable[Concatenate[Point[T], bool, P], S]:
     from chirho.robust.internals.linearize import linearize
     from chirho.robust.internals.predictive import PredictiveFunctional
     from chirho.robust.internals.utils import make_functional_call
@@ -53,6 +53,7 @@ def influence_fn(
                 lambda p: func_target(p, *args, **kwargs), (target_params,), (d,)
             )[1],
             in_dims=0,
+            randomness="different",
         )(param_eif)
 
     return _fn

--- a/tests/robust/robust_fixtures.py
+++ b/tests/robust/robust_fixtures.py
@@ -18,26 +18,29 @@ class SimpleModel(PyroModule):
     def __init__(
         self,
         link_fn: Callable[..., dist.Distribution] = lambda mu: dist.Normal(mu, 1.0),
+        p: int = 3,
     ):
         super().__init__()
         self.link_fn = link_fn
+        self.p = p
 
     def forward(self):
         a = pyro.sample("a", dist.Normal(0, 1))
-        with pyro.plate("data", 3, dim=-1):
+        with pyro.plate("data", self.p, dim=-1):
             b = pyro.sample("b", dist.Normal(a, 1))
             return pyro.sample("y", dist.Normal(b, 1))
 
 
 class SimpleGuide(torch.nn.Module):
-    def __init__(self):
+    def __init__(self, p: int = 3):
         super().__init__()
         self.loc_a = torch.nn.Parameter(torch.rand(()))
-        self.loc_b = torch.nn.Parameter(torch.rand((3,)))
+        self.loc_b = torch.nn.Parameter(torch.rand((p,)))
+        self.p = p
 
     def forward(self):
         a = pyro.sample("a", dist.Normal(self.loc_a, 1))
-        with pyro.plate("data", 3, dim=-1):
+        with pyro.plate("data", self.p, dim=-1):
             b = pyro.sample("b", dist.Normal(self.loc_b, 1))
             return {"a": a, "b": b}
 

--- a/tests/robust/test_internals_compositions.py
+++ b/tests/robust/test_internals_compositions.py
@@ -44,12 +44,16 @@ def test_empirical_fisher_vp_nmclikelihood_cg_composition(prob_config):
 
     with torch.no_grad():
         data = func_predictive(predictive_params)
-    fvp = make_empirical_fisher_vp(
-        func_log_prob, log_prob_params, data, is_batched=is_batched
+    fvp = torch.func.vmap(
+        make_empirical_fisher_vp(
+            func_log_prob, log_prob_params, data, is_batched=is_batched
+        )
     )
 
     v = {
-        k: torch.ones_like(v) if k != "guide.loc_a" else torch.zeros_like(v)
+        k: torch.ones_like(v).unsqueeze(0)
+        if k != "guide.loc_a"
+        else torch.zeros_like(v).unsqueeze(0)
         for k, v in log_prob_params.items()
     }
 

--- a/tests/robust/test_ops.py
+++ b/tests/robust/test_ops.py
@@ -120,8 +120,7 @@ def test_nmc_predictive_influence_vmap_smoke(
             model, num_samples=4, return_sites=obs_names, parallel=True
         )()
 
-    batch_predictive_eif = torch.vmap(predictive_eif, randomness="different")
-    test_data_eif: Mapping[str, torch.Tensor] = batch_predictive_eif(test_data)
+    test_data_eif: Mapping[str, torch.Tensor] = predictive_eif(test_data)
     assert len(test_data_eif) > 0
     for k, v in test_data_eif.items():
         assert not torch.isnan(v).any(), f"eif for {k} had nans"

--- a/tests/robust/test_performance.py
+++ b/tests/robust/test_performance.py
@@ -1,14 +1,22 @@
 import time
 from functools import partial
 
+import pyro
 import pytest
 import torch
 from pyro.infer.predictive import Predictive
 
 from chirho.robust.internals.linearize import make_empirical_fisher_vp
+from chirho.robust.internals.predictive import (
+    NMCLogPredictiveLikelihood,
+    PointLogPredictiveLikelihood,
+)
+from chirho.robust.internals.utils import make_functional_call
 
 from .robust_fixtures import (
     GaussianModel,
+    SimpleGuide,
+    SimpleModel,
     _make_fisher_jvp_score_formulation,
     gaussian_log_prob,
     gaussian_log_prob_flattened,
@@ -54,3 +62,86 @@ def test_empirical_fisher_vp_performance():
     fisher_score_batched(v)
     end_time = time.time()
     print("Score manual batched time (s): ", end_time - start_time)
+
+
+class SimpleMultivariateGaussianModel(pyro.nn.PyroModule):
+    def __init__(self, p):
+        super().__init__()
+        self.p = p
+
+    def forward(self):
+        loc = pyro.sample(
+            "loc", pyro.distributions.Normal(torch.zeros(self.p), 1.0).to_event(1)
+        )
+        cov_mat = torch.eye(self.p)
+        return pyro.sample("y", pyro.distributions.MultivariateNormal(loc, cov_mat))
+
+
+class SimpleMultivariateGuide(torch.nn.Module):
+    def __init__(self, p):
+        super().__init__()
+        self.loc_ = torch.nn.Parameter(torch.rand((p,)))
+        self.p = p
+
+    def forward(self):
+        return pyro.sample("loc", pyro.distributions.Normal(self.loc_, 1).to_event(1))
+
+
+model_guide_types = [
+    (SimpleMultivariateGaussianModel, SimpleMultivariateGuide),
+    (SimpleModel, SimpleGuide),
+]
+
+
+@pytest.mark.skip(reason="This test is too slow to run on CI")
+@pytest.mark.parametrize("model_guide", model_guide_types)
+def test_empirical_fisher_vp_performance_with_likelihood(model_guide):
+    p = 500
+    num_monte_carlo = 10000
+    model_family, guide_family = model_guide
+
+    model = model_family(p=p)
+    guide = guide_family(p=p)
+
+    model()
+    guide()
+
+    start_time = time.time()
+    data = Predictive(
+        model, guide=guide, num_samples=num_monte_carlo, return_sites=["y"]
+    )()
+    end_time = time.time()
+    print("Data generation time (s): ", end_time - start_time)
+
+    log1_prob_params, func1_log_prob = make_functional_call(
+        NMCLogPredictiveLikelihood(model, guide)
+    )
+
+    log2_prob_params, func2_log_prob = make_functional_call(
+        PointLogPredictiveLikelihood(model, guide)
+    )
+
+    fisher_hessian_vmapped = make_empirical_fisher_vp(
+        func1_log_prob, log1_prob_params, data, is_batched=False
+    )
+
+    fisher_hessian_batched = make_empirical_fisher_vp(
+        func2_log_prob, log2_prob_params, data, is_batched=True
+    )
+
+    v = {
+        k: torch.ones_like(v) if k != "guide.loc_a" else torch.zeros_like(v)
+        for k, v in log1_prob_params.items()
+    }
+
+    func2_log_prob(log2_prob_params, data)
+
+    start_time = time.time()
+    fisher_hessian_vmapped(v)
+    end_time = time.time()
+    print("Hessian vmapped time (s): ", end_time - start_time)
+
+    start_time = time.time()
+    fisher_hessian_batched(v)
+    end_time = time.time()
+    print("Hessian manual batched time (s): ", end_time - start_time)

--- a/tests/robust/test_performance.py
+++ b/tests/robust/test_performance.py
@@ -1,0 +1,56 @@
+import time
+from functools import partial
+
+import pytest
+import torch
+from pyro.infer.predictive import Predictive
+
+from chirho.robust.internals.linearize import make_empirical_fisher_vp
+
+from .robust_fixtures import (
+    GaussianModel,
+    _make_fisher_jvp_score_formulation,
+    gaussian_log_prob,
+    gaussian_log_prob_flattened,
+)
+
+
+@pytest.mark.skip(reason="This test is too slow to run on CI")
+def test_empirical_fisher_vp_performance():
+    p = 500
+    loc = torch.tensor(1.0 * torch.ones(p), requires_grad=True)
+    cov_mat = torch.eye(p)
+    v = torch.ones(p)
+    func_log_prob = gaussian_log_prob
+    log_prob_params = {"loc": loc}
+    num_monte_carlo = 10000
+    start_time = time.time()
+    data = Predictive(GaussianModel(cov_mat), num_samples=num_monte_carlo)(loc)
+    end_time = time.time()
+    print("Data generation time (s): ", end_time - start_time)
+
+    fisher_hessian_vmapped = make_empirical_fisher_vp(
+        func_log_prob, log_prob_params, data, is_batched=False, cov_mat=cov_mat
+    )
+
+    fisher_hessian_batched = make_empirical_fisher_vp(
+        func_log_prob, log_prob_params, data, is_batched=True, cov_mat=cov_mat
+    )
+
+    f = partial(gaussian_log_prob_flattened, data_point=data, cov_mat=cov_mat)
+    fisher_score_batched = _make_fisher_jvp_score_formulation(f, loc, num_monte_carlo)
+
+    start_time = time.time()
+    fisher_hessian_vmapped({"loc": v})
+    end_time = time.time()
+    print("Hessian vmapped time (s): ", end_time - start_time)
+
+    start_time = time.time()
+    fisher_hessian_batched({"loc": v})
+    end_time = time.time()
+    print("Hessian manual batched time (s): ", end_time - start_time)
+
+    start_time = time.time()
+    fisher_score_batched(v)
+    end_time = time.time()
+    print("Score manual batched time (s): ", end_time - start_time)


### PR DESCRIPTION
There are three main performance improvements:

1. Optimization when guide is a point estimate
If the guide is only a point estimate, using `NMCLogPredictiveLikelihood`, which relies on `torch.func.vmap` to batch over multiple datapoints can be orders of magnitude slower than manually batching the likelihood. In `test_empirical_fisher_vp_performance_with_likelihood` in `test_performance.py`,  we see that `NMCLogPredictiveLikelihood` can be 200x slower than manually vectorizing the likelihood using the new class `PointLogPredictiveLikelihood`.

2. Manually batching in `_flat_conjugate_gradient_solve`
One big performance hit was using `torch.func.vmap` to batch over multiple conjugate gradient solves. Since `torch.func.vmap` does not allow conditional if/else statements, the conjugate gradient solver cannot terminate earlier if the error tolerance is met. In this PR, we batch the conjugate gradient solver without using `torch.func.vmap` so that we can use conditional statements. In one experiment, I was able to run only 23 congugate gradient steps instead of a few hundred to reach error tolerance. This behavior is also exploited here: https://arxiv.org/abs/1903.08114. 

4. Batching over multiple points in `linearize` and `influence_fn`
As shown in  `test_performance.py`, simulating synthetic data from the model can be the most lengthy step. In the previous implementation, data is simulated each time the influence function is evaluated at a single point. In this PR, we evaluate the influence function over multiple points so that we only need to simulate data once.

Closes #451 