### PR TITLE
implement `soft_eq` and `soft_neq` 

### DIFF
--- a/chirho/explainable/internals/defaults.py
+++ b/chirho/explainable/internals/defaults.py
@@ -2,7 +2,12 @@ import functools
 from typing import TypeVar
 
 import pyro
+import pyro.distributions as dist
+import pyro.distributions.constraints as constraints
 import torch
+from torch.distributions import biject_to
+
+from chirho.indexed.ops import cond
 
 S = TypeVar("S")
 T = TypeVar("T")
@@ -60,3 +65,118 @@ def _uniform_proposal_integer(
         )
     n = support.upper_bound - support.lower_bound + 1
     return pyro.distributions.Categorical(probs=torch.ones((n,)))
+
+
+@functools.singledispatch
+def soft_eq(support: constraints.Constraint, v1: T, v2: T, **kwargs) -> torch.Tensor:
+    """
+    Computes soft equality between two values `v1` and `v2` given a distribution constraint `support`.
+    Returns a negative value if there is a difference (the larger the difference, the lower the value)
+    and tends to `Norm(0,1).log_prob(0)` as `v1` and `v2` tend to each other,
+    except for when the support is boolean, in which case it returns `0.0` if the values are equal
+    and a large negative number (`eps`) otherwise.
+
+    :param support: distribution constraint (`real`/`boolean`/`positive`/`interval`).
+    :params v1, v2: the values to be compared.
+    :param kwargs: Additional keywords arguments:
+        - for boolean, the function expects `eps` to set a large negative value for.
+        - For interval and real constraints, `scale` adjusts the softness of the inequality.
+    :return: A tensor of log probabilities capturing the soft equality between `v1` and `v2`.
+    :raises TypeError: If boolean tensors have different data types.
+    """
+    if not isinstance(v1, torch.Tensor) or not isinstance(v2, torch.Tensor):
+        raise NotImplementedError("Soft equality is only implemented for tensors.")
+    elif support.is_discrete:
+        raise NotImplementedError(
+            "Soft equality is not implemented for arbitrary discrete distributions."
+        )
+    elif support is constraints.real:  # base case
+        scale = kwargs.get("scale", 0.1)
+        return dist.Normal(0.0, scale).log_prob(v1 - v2)
+    else:
+        tfm = biject_to(support)
+        v1_inv = tfm.inv(v1)
+        ldj = tfm.log_abs_det_jacobian(v1_inv, v1)
+        v2_inv = tfm.inv(v2)
+        ldj = ldj + tfm.log_abs_det_jacobian(v2_inv, v2)
+        for _ in range(tfm.codomain.event_dim - tfm.domain.event_dim):
+            ldj = torch.sum(ldj, dim=-1)
+        return soft_eq(tfm.domain, v1_inv, v2_inv, **kwargs) + ldj
+
+
+@soft_eq.register
+def _soft_eq_independent(support: constraints.independent, v1: T, v2: T, **kwargs):
+    result = soft_eq(support.base_constraint, v1, v2, **kwargs)
+    for _ in range(support.reinterpreted_batch_ndims):
+        result = torch.sum(result, dim=-1)
+    return result
+
+
+@soft_eq.register(type(constraints.boolean))
+def _soft_eq_boolean(
+    support: constraints.Constraint, v1: torch.Tensor, v2: torch.Tensor, **kwargs
+):
+    assert support is constraints.boolean
+    scale = kwargs.get("scale", 0.1)
+    return torch.log(cond(scale, 1 - scale, v1 == v2, event_dim=0))
+
+
+@soft_eq.register
+def _soft_eq_integer_interval(
+    support: constraints.integer_interval, v1: torch.Tensor, v2: torch.Tensor, **kwargs
+):
+    scale = kwargs.get("scale", 0.1)
+    width = support.upper_bound - support.lower_bound + 1
+    return dist.Binomial(total_count=width, probs=scale).log_prob(torch.abs(v1 - v2))
+
+
+@soft_eq.register(type(constraints.integer))
+def _soft_eq_integer(
+    support: constraints.Constraint, v1: torch.Tensor, v2: torch.Tensor, **kwargs
+):
+    scale = kwargs.get("scale", 0.1)
+    return dist.Poisson(rate=scale).log_prob(torch.abs(v1 - v2))
+
+
+@soft_eq.register(type(constraints.positive_integer))
+@soft_eq.register(type(constraints.nonnegative_integer))
+def _soft_eq_positive_integer(support: constraints.Constraint, v1: T, v2: T, **kwargs):
+    return soft_eq(constraints.integer, v1, v2, **kwargs)
+
+
+@functools.singledispatch
+def soft_neq(support: constraints.Constraint, v1: T, v2: T, **kwargs) -> torch.Tensor:
+    """
+    Computes soft inequality between two values `v1` and `v2` given a distribution constraint `support`.
+    Tends to zero as the difference between the value increases, and tends to
+    `-eps / (Norm(0,scale).log_prob(0) - 1e-10)` as `v1` and `v2` tend to each other.
+
+    :param support: distribution constraint (`real`/`boolean`/`positive`/`interval`).
+    :params v1, v2: the values to be compared.
+    :param kwargs: Additional keywords arguments:
+        - for boolean, the function expects `eps` to set a large negative value for.
+        - For interval and real constraints, the function expects `eps` to fix the minimal value and
+        `scale` to adjust the softness of the inequality.
+    :return: A tensor of log probabilities capturing the soft inequality between `v1` and `v2`.
+    :raises TypeError: If boolean tensors have different data types.
+    :raises ValueError: If the specified scale is less than `1 / sqrt(2 * pi)`, to ensure that the log
+                        probabilities used in calculations are are nonpositive.
+    """
+    if not isinstance(v1, torch.Tensor) or not isinstance(v2, torch.Tensor):
+        raise NotImplementedError("Soft equality is only implemented for tensors.")
+    elif support.is_discrete:  # for discrete pmf, soft_neq = 1 - soft_eq (in log space)
+        return torch.log(-torch.expm1(soft_eq(support, v1, v2, **kwargs)))
+    elif support is constraints.real:  # base case
+        scale = kwargs.get("scale", 0.1)
+        return torch.log(2 * dist.Normal(0.0, scale).cdf(torch.abs(v1 - v2)) - 1)
+    else:
+        tfm = biject_to(support)
+        return soft_neq(tfm.domain, tfm.inv(v1), tfm.inv(v2), **kwargs)
+
+
+@soft_neq.register
+def _soft_neq_independent(support: constraints.independent, v1: T, v2: T, **kwargs):
+    result = soft_neq(support.base_constraint, v1, v2, **kwargs)
+    for _ in range(support.reinterpreted_batch_ndims):
+        result = torch.sum(result, dim=-1)
+    return result

--- a/chirho/explainable/ops.py
+++ b/chirho/explainable/ops.py
@@ -72,10 +72,6 @@ def soft_eq(support: constraints.Constraint, v1: T, v2: T, **kwargs) -> torch.Te
         scale = kwargs.get("scale", 0.1)
         return dist.Normal(0.0, scale).log_prob(v1 - v2)
     else:
-        # generative process:
-        #   u1, u2 ~ base_dist
-        #   v1 ~ tfm(u1), v2 ~ tfm(u2)
-        #   ud = u1 - u2 ~ base_dist
         tfm = biject_to(support)
         v1_inv = tfm.inv(v1)
         ldj = tfm.log_abs_det_jacobian(v1_inv, v1)

--- a/chirho/explainable/ops.py
+++ b/chirho/explainable/ops.py
@@ -81,7 +81,7 @@ def soft_eq(support: constraints.Constraint, v1: T, v2: T, **kwargs) -> torch.Te
     if support is constraints.real:
         return dist.Normal(0, kwargs.get("scale", kwargs.get("scale", 0.1))).log_prob(
             v1 - v2
-        )
+        ) - dist.Normal(0, kwargs.get("scale", 0.1)).log_prob(torch.tensor(0.0))
 
     else:
         tfm = biject_to(support).inv
@@ -96,7 +96,9 @@ def soft_eq(support: constraints.Constraint, v1: T, v2: T, **kwargs) -> torch.Te
             diff = torch.abs(v1 - v2)
             diff_transformed = tfm(diff)
 
-    return dist.Normal(0, kwargs.get("scale", default_scale)).log_prob(diff_transformed)
+    return dist.Normal(0, kwargs.get("scale", default_scale)).log_prob(
+        diff_transformed
+    ) - (dist.Normal(0, kwargs.get("scale", default_scale)).log_prob(torch.tensor(0.0)))
 
 
 def consequent_differs(

--- a/chirho/explainable/ops.py
+++ b/chirho/explainable/ops.py
@@ -104,6 +104,22 @@ def soft_eq(support: constraints.Constraint, v1: T, v2: T, **kwargs) -> torch.Te
 
 @functools.singledispatch
 def soft_neq(support: constraints.Constraint, v1: T, v2: T, **kwargs) -> torch.Tensor:
+    """
+    Computes soft inequality between two values `v1` and `v2` given a distribution constraint `support`.
+    Tends to zero as the difference between the value increases, and tends to
+    `-eps / (Norm(0,scale).log_prob(0) - 1e-10)` as `v1` and `v2` tend to each other.
+
+    :param support: distribution constraint (`real`/`boolean`/`positive`/`interval`).
+    :params v1, v2: the values to be compared.
+    :param kwargs: Additional keywords arguments:
+        - for boolean, the function expects `eps` to set a large negative value for.
+        - For interval and real constraints, the function expects `eps` to fix the minimal value and
+        `scale` to adjust the softness of the inequality.
+    :return: A tensor of log probabilities capturing the soft inequality between `v1` and `v2`.
+    :raises TypeError: If boolean tensors have different data types.
+    :raises ValueError: If the specified scale is less than `1 / sqrt(2 * pi)`, to ensure that the log
+                        probabilities used in calculations are are nonpositive.
+    """
     eps = kwargs.get("eps", -1e8)
 
     if support is constraints.boolean and hasattr(v1, "dtype") and hasattr(v2, "dtype"):

--- a/chirho/explainable/ops.py
+++ b/chirho/explainable/ops.py
@@ -2,10 +2,7 @@ import functools
 from typing import Any, Callable, Iterable, Optional, Tuple, TypeVar
 
 import pyro
-import pyro.distributions as dist
-import pyro.distributions.constraints as constraints
 import torch
-from torch.distributions import biject_to
 
 from chirho.counterfactual.handlers.selection import get_factual_indices
 from chirho.indexed.ops import IndexSet, cond, cond_n, gather
@@ -47,113 +44,6 @@ def preempt(
     return cond_n(act_values, case, event_dim=kwargs.get("event_dim", 0))
 
 
-@functools.singledispatch
-def soft_eq(support: constraints.Constraint, v1: T, v2: T, **kwargs) -> torch.Tensor:
-    """
-    Computes soft equality between two values `v1` and `v2` given a distribution constraint `support`.
-    Returns a negative value if there is a difference (the larger the difference, the lower the value)
-    and tends to `Norm(0,1).log_prob(0)` as `v1` and `v2` tend to each other,
-    except for when the support is boolean, in which case it returns `0.0` if the values are equal
-    and a large negative number (`eps`) otherwise.
-
-    :param support: distribution constraint (`real`/`boolean`/`positive`/`interval`).
-    :params v1, v2: the values to be compared.
-    :param kwargs: Additional keywords arguments:
-        - for boolean, the function expects `eps` to set a large negative value for.
-        - For interval and real constraints, `scale` adjusts the softness of the inequality.
-    :return: A tensor of log probabilities capturing the soft equality between `v1` and `v2`.
-    :raises TypeError: If boolean tensors have different data types.
-    """
-    if support.is_discrete:
-        raise NotImplementedError(
-            "Soft equality is not implemented for arbitrary discrete distributions."
-        )
-    elif support is constraints.real:  # base case
-        scale = kwargs.get("scale", 0.1)
-        return dist.Normal(0.0, scale).log_prob(v1 - v2)
-    else:
-        tfm = biject_to(support)
-        v1_inv = tfm.inv(v1)
-        ldj = tfm.log_abs_det_jacobian(v1_inv, v1)
-        v2_inv = tfm.inv(v2)
-        ldj = ldj + tfm.log_abs_det_jacobian(v2_inv, v2)
-        for _ in range(tfm.codomain.event_dim - tfm.domain.event_dim):
-            ldj = torch.sum(ldj, dim=-1)
-        return soft_eq(tfm.domain, v1_inv, v2_inv, **kwargs) + ldj
-
-
-@soft_eq.register
-def _soft_eq_independent(support: constraints.independent, v1: T, v2: T, **kwargs):
-    result = soft_eq(support.base_constraint, v1, v2, **kwargs)
-    for _ in range(support.reinterpreted_batch_ndims):
-        result = torch.sum(result, dim=-1)
-    return result
-
-
-@soft_eq.register(type(constraints.boolean))
-def _soft_eq_boolean(support: constraints.Constraint, v1: T, v2: T, **kwargs):
-    assert support is constraints.boolean
-    scale = kwargs.get("scale", 0.1)
-    return torch.log(cond(scale, 1 - scale, v1 == v2, event_dim=0))
-
-
-@soft_eq.register
-def _soft_eq_integer_interval(
-    support: constraints.integer_interval, v1: T, v2: T, **kwargs
-):
-    scale = kwargs.get("scale", 0.1)
-    width = support.upper_bound - support.lower_bound + 1
-    return dist.Binomial(total_count=width, probs=scale).log_prob(torch.abs(v1 - v2))
-
-
-@soft_eq.register(type(constraints.integer))
-def _soft_eq_integer(support: constraints.Constraint, v1: T, v2: T, **kwargs):
-    scale = kwargs.get("scale", 0.1)
-    return dist.Poisson(rate=scale).log_prob(torch.abs(v1 - v2))
-
-
-@soft_eq.register(type(constraints.positive_integer))
-@soft_eq.register(type(constraints.nonnegative_integer))
-def _soft_eq_positive_integer(support: constraints.Constraint, v1: T, v2: T, **kwargs):
-    return soft_eq(constraints.integer, v1, v2, **kwargs)
-
-
-@functools.singledispatch
-def soft_neq(support: constraints.Constraint, v1: T, v2: T, **kwargs) -> torch.Tensor:
-    """
-    Computes soft inequality between two values `v1` and `v2` given a distribution constraint `support`.
-    Tends to zero as the difference between the value increases, and tends to
-    `-eps / (Norm(0,scale).log_prob(0) - 1e-10)` as `v1` and `v2` tend to each other.
-
-    :param support: distribution constraint (`real`/`boolean`/`positive`/`interval`).
-    :params v1, v2: the values to be compared.
-    :param kwargs: Additional keywords arguments:
-        - for boolean, the function expects `eps` to set a large negative value for.
-        - For interval and real constraints, the function expects `eps` to fix the minimal value and
-        `scale` to adjust the softness of the inequality.
-    :return: A tensor of log probabilities capturing the soft inequality between `v1` and `v2`.
-    :raises TypeError: If boolean tensors have different data types.
-    :raises ValueError: If the specified scale is less than `1 / sqrt(2 * pi)`, to ensure that the log
-                        probabilities used in calculations are are nonpositive.
-    """
-    if support.is_discrete:  # for discrete pmf, soft_neq = 1 - soft_eq (in log space)
-        return torch.log(-torch.expm1(soft_eq(support, v1, v2, **kwargs)))
-    elif support is constraints.real:  # base case
-        scale = kwargs.get("scale", 0.1)
-        return torch.log(2 * dist.Normal(0.0, scale).cdf(torch.abs(v1 - v2)) - 1)
-    else:
-        tfm = biject_to(support)
-        return soft_neq(tfm.domain, tfm.inv(v1), tfm.inv(v2), **kwargs)
-
-
-@soft_neq.register
-def _soft_neq_independent(support: constraints.independent, v1: T, v2: T, **kwargs):
-    result = soft_neq(support.base_constraint, v1, v2, **kwargs)
-    for _ in range(support.reinterpreted_batch_ndims):
-        result = torch.sum(result, dim=-1)
-    return result
-
-
 def consequent_differs(
     antecedents: Iterable[str] = [], eps: float = -1e8, event_dim: int = 0
 ) -> Callable[[T], torch.Tensor]:
@@ -178,6 +68,7 @@ def consequent_differs(
                 if name in antecedents
             }
         )
+        # TODO replace this logic with soft_neq
         not_eq: torch.Tensor = consequent != gather(
             consequent, indices, event_dim=event_dim
         )

--- a/chirho/explainable/ops.py
+++ b/chirho/explainable/ops.py
@@ -74,7 +74,7 @@ def soft_eq(support: constraints.Constraint, v1: T, v2: T, **kwargs) -> torch.Te
     else:
         # generative process:
         #   u1, u2 ~ base_dist
-        #   v1 = tfm(u1), v2 = tfm(u2)
+        #   v1 ~ tfm(u1), v2 ~ tfm(u2)
         #   ud = u1 - u2 ~ base_dist
         tfm = biject_to(support)
         v1_inv = tfm.inv(v1)
@@ -144,7 +144,7 @@ def soft_neq(support: constraints.Constraint, v1: T, v2: T, **kwargs) -> torch.T
         return torch.log(-torch.expm1(soft_eq(support, v1, v2, **kwargs)))
     elif support is constraints.real:  # base case
         scale = kwargs.get("scale", 0.1)
-        return torch.log(2 * dist.Normal(0., scale).cdf(torch.abs(v1 - v2)) - 1)
+        return torch.log(2 * dist.Normal(0.0, scale).cdf(torch.abs(v1 - v2)) - 1)
     else:
         tfm = biject_to(support)
         return soft_neq(tfm.domain, tfm.inv(v1), tfm.inv(v2), **kwargs)

--- a/chirho/explainable/ops.py
+++ b/chirho/explainable/ops.py
@@ -79,7 +79,7 @@ def soft_eq(support: constraints.Constraint, v1: T, v2: T, **kwargs) -> torch.Te
         ldj = ldj + tfm.log_abs_det_jacobian(v2_inv, v2)
         for _ in range(tfm.codomain.event_dim - tfm.domain.event_dim):
             ldj = torch.sum(ldj, dim=-1)
-        return soft_eq(tfm.domain, v1_inv, v2_inv, **kwargs) - ldj
+        return soft_eq(tfm.domain, v1_inv, v2_inv, **kwargs) + ldj
 
 
 @soft_eq.register

--- a/chirho/explainable/ops.py
+++ b/chirho/explainable/ops.py
@@ -68,7 +68,6 @@ def consequent_differs(
                 if name in antecedents
             }
         )
-        # TODO replace this logic with soft_neq
         not_eq: torch.Tensor = consequent != gather(
             consequent, indices, event_dim=event_dim
         )

--- a/chirho/explainable/ops.py
+++ b/chirho/explainable/ops.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Any, Callable, Iterable, Optional, Tuple, TypeVar
+from typing import Callable, Iterable, Optional, Tuple, TypeVar
 
 import pyro
 import torch
@@ -9,7 +9,7 @@ from chirho.indexed.ops import IndexSet, cond, cond_n, gather
 from chirho.interventional.ops import Intervention, intervene
 
 S = TypeVar("S")
-T = TypeVar("T", bound=Any)
+T = TypeVar("T")
 
 
 @pyro.poutine.runtime.effectful(type="preempt")

--- a/chirho/explainable/ops.py
+++ b/chirho/explainable/ops.py
@@ -79,7 +79,7 @@ def soft_eq(support: constraints.Constraint, v1: T, v2: T, **kwargs) -> torch.Te
         return cond(eps, 0.0, eq, event_dim=event_dim)
 
     if support is constraints.real:
-        return dist.Normal(0, kwargs.get("scale", kwargs.get("scale", 1.0))).log_prob(
+        return dist.Normal(0, kwargs.get("scale", kwargs.get("scale", 0.1))).log_prob(
             v1 - v2
         )
 
@@ -92,7 +92,7 @@ def soft_eq(support: constraints.Constraint, v1: T, v2: T, **kwargs) -> torch.Te
             diff = torch.abs(v1 - v2)
             diff_transformed = diff / interval_range
         else:
-            default_scale = kwargs.get("scale", 1.0)
+            default_scale = kwargs.get("scale", 0.1)
             diff = torch.abs(v1 - v2)
             diff_transformed = tfm(diff)
 

--- a/chirho/explainable/ops.py
+++ b/chirho/explainable/ops.py
@@ -2,14 +2,17 @@ import functools
 from typing import Any, Callable, Iterable, Optional, Tuple, TypeVar
 
 import pyro
-import pyro.distributions as dist
-import pyro.distributions.constraints as constraints
+
+# import pyro.distributions as dist
+# import pyro.distributions.constraints as constraints
 import torch
-from torch.distributions import biject_to
 
 from chirho.counterfactual.handlers.selection import get_factual_indices
 from chirho.indexed.ops import IndexSet, cond, cond_n, gather
 from chirho.interventional.ops import Intervention, intervene
+
+# from torch.distributions import biject_to
+
 
 S = TypeVar("S")
 T = TypeVar("T", bound=Any)
@@ -45,39 +48,6 @@ def preempt(
         act_values[IndexSet(**{name: {i + 1}})] = intervene(obs, act, **kwargs)
 
     return cond_n(act_values, case, event_dim=kwargs.get("event_dim", 0))
-
-
-@functools.singledispatch
-def soft_neq(support: constraints.Constraint, v1: T, v2: T, **kwargs) -> torch.Tensor:
-    if isinstance(support, constraints.interval):
-        default_scale = 10 * abs(support.upper_bound - support.lower_bound)
-    else:
-        default_scale = 0.1
-
-    if support is constraints.boolean and hasattr(v1, "dtype") and hasattr(v2, "dtype"):
-        if v1.dtype != v2.dtype:
-            raise TypeError("Boolean tensors have to be of the same dtype.")
-
-        eps = kwargs.get("eps", -1e8)
-        event_dim = kwargs.get("event_dim", 0)
-        neq: torch.Tensor = v1 != v2
-
-        for _ in range(event_dim):
-            neq = torch.all(neq, dim=-1, keepdim=False)
-
-        return cond(eps, 0.0, neq, event_dim=event_dim)
-
-    if support is constraints.real:
-        return dist.Normal(0, kwargs.get("scale", default_scale)).log_prob(v1 - v2)
-
-    else:
-        tfm = biject_to(support).inv
-        diff = torch.abs(v1 - v2)
-        diff_unconstrained = tfm(diff)
-
-        return dist.Normal(0, kwargs.get("scale", default_scale)).log_prob(
-            diff_unconstrained
-        )
 
 
 def consequent_differs(

--- a/tests/explainable/test_ops.py
+++ b/tests/explainable/test_ops.py
@@ -66,23 +66,8 @@ def test_soft_boolean():
     )
 
 
-def test_soft_positive():
-    scale = 1e-1
-    t1 = torch.arange(1, 50, 1)
-    t2 = t1 + 3
-
-    pos_eq = soft_eq(constraints.positive, t1, t2, scale=scale)
-    pos_neq = soft_neq(constraints.positive, t1, t2, scale=scale)
-    assert torch.allclose(
-        pos_eq, pos_eq[0], rtol=0.001
-    ), "soft_eq is not a function of the absolute distance between the two original values"
-    assert torch.allclose(
-        pos_neq, pos_neq[0], rtol=0.001
-    ), "soft_neq is not a function of the absolute distance between the two original values"
-
-
 def test_soft_interval():
-    scale = 1.
+    scale = 1.0
     t1 = torch.arange(0.5, 7.5, 0.1)
     t2 = t1 + 1
     t2b = t1 + 2
@@ -101,23 +86,14 @@ def test_soft_interval():
         inter_neq_b > inter_neq
     ), "soft_neq is not monotonic in the absolute distance between the two original values"
     assert (
-        soft_neq(constraints.interval(0, 10), torch.tensor(0.0), torch.tensor(10.0), scale=scale)
+        soft_neq(
+            constraints.interval(0, 10),
+            torch.tensor(0.0),
+            torch.tensor(10.0),
+            scale=scale,
+        )
         == 0
     ), "soft_neq is not zero at maximal difference"
-
-    inter_eq_10 = soft_eq(constraints.interval(0, 10), t1, t2, scale=scale)
-    inter_eq_20 = soft_eq(constraints.interval(-10, 10), t1, t2b, scale=scale)
-
-    inter_neq_10 = soft_neq(constraints.interval(0, 10), t1, t2, scale=scale)
-    inter_neq_20 = soft_neq(constraints.interval(-10, 10), t1, t2b, scale=scale)
-
-    assert torch.allclose(
-        inter_eq_10, inter_eq_20, rtol=0.001
-    ), "soft_eq does not scale with  interval"
-
-    assert torch.allclose(
-        inter_neq_10, inter_neq_20, rtol=0.001
-    ), "soft_neq does not scale with interval"
 
 
 def test_soft_eq_tavares_relaxation():

--- a/tests/explainable/test_ops.py
+++ b/tests/explainable/test_ops.py
@@ -1,5 +1,6 @@
 import pyro
 import pyro.distributions as dist
+import pyro.distributions.constraints as constraints
 import pyro.infer
 import pytest
 import torch
@@ -9,7 +10,7 @@ from chirho.counterfactual.handlers import (
     SingleWorldCounterfactual,
 )
 from chirho.counterfactual.ops import split
-from chirho.explainable.ops import consequent_differs, preempt
+from chirho.explainable.ops import consequent_differs, preempt, soft_neq
 from chirho.indexed.ops import IndexSet, gather
 from chirho.observational.handlers.condition import Factors
 
@@ -35,6 +36,61 @@ def test_preempt_op_singleworld():
     tr = pyro.poutine.trace(model).get_trace()
     assert torch.all(tr.nodes["x_"]["value"] == 0.0)
     assert torch.all(tr.nodes["y_"]["value"] == 1.0)
+
+
+def test_soft_neq_boolean():
+    support = constraints.boolean
+
+    boolean_tensor_1 = torch.tensor([True, False, True, False])
+    boolean_tensor_2 = torch.tensor([True, True, False, False])
+
+    log_boolean_neq = soft_neq(support, boolean_tensor_1, boolean_tensor_2)
+
+    real_tensor_1 = torch.tensor([1.0, 0.0, 1.0, 0.0])
+    real_tensor_2 = torch.tensor([1.0, 1.0, 0.0, 0.0])
+
+    real_boolean_neq = soft_neq(support, real_tensor_1, real_tensor_2)
+
+    with pytest.raises(
+        TypeError, match="Boolean tensors have to be of the same dtype."
+    ):
+        soft_neq(support, boolean_tensor_1, real_tensor_1)
+
+    assert torch.equal(log_boolean_neq, real_boolean_neq) and torch.equal(
+        real_boolean_neq, torch.tensor([-1e8, 0.0, 0.0, -1e8])
+    )
+
+
+def test_soft_neq_positive():
+    t1 = torch.arange(0, 50, 1)
+    t2 = t1 + 3
+    pos_neq = soft_neq(constraints.positive, t1, t2, scale=0.1)
+    assert torch.allclose(
+        pos_neq, pos_neq[0], rtol=0.001
+    ), "soft_neq is not a function of the absolute distance between the two original values"
+
+
+def test_soft_neq_interval():
+    t1 = torch.arange(0, 8, 0.1)
+    t2 = t1 + 1
+    t2b = t1 + 2
+    inter_neq = soft_neq(constraints.interval(0, 10), t1, t2, scale=100)
+    inter_neq_b = soft_neq(constraints.interval(0, 10), t1, t2b, scale=100)
+
+    assert torch.all(
+        inter_neq_b > inter_neq
+    ), "soft_neq is not monotonic in the absolute distance between the two original values"
+
+    assert torch.allclose(
+        inter_neq, inter_neq[0], rtol=0.001
+    ), "soft_neq is not a function of the absolute distance between the two original values"
+
+    inter_neq_10 = soft_neq(constraints.interval(0, 10), t1, t2, scale=100)
+    inter_neq_20 = soft_neq(constraints.interval(-10, 10), t1, t2b, scale=100)
+
+    assert torch.allclose(
+        inter_neq_10, inter_neq_20, rtol=0.001
+    ), "soft_neq does not scale with interval"
 
 
 @pytest.mark.parametrize("plate_size", [4, 50, 200])

--- a/tests/explainable/test_ops.py
+++ b/tests/explainable/test_ops.py
@@ -97,6 +97,35 @@ def test_soft_eq_interval():
     ), "soft_eq does noh interval"
 
 
+def test_soft_eq_relaxation():
+    # these test cases are for our counterpart
+    # of conditions (i)-(iii) of predicate relaxation
+    # from "Predicate exchange..." by Tavares et al.
+
+    # condition i: when a tends to zero, soft_eq tends to the true only for
+    # true identity and to negative infinity otherwise
+    support = constraints.real
+    assert (
+        soft_eq(support, torch.tensor(1.0), torch.tensor(1.001), scale=1e-10) < 1e-10
+    ), "soft_eq does not tend to negative infinity for false identities as a tends to zero"
+
+    # condition ii: approaching true answer as scale goes to infty
+    scales = [1e6, 1e10]
+    for scale in scales:
+        score_diff = soft_eq(support, torch.tensor(1.0), torch.tensor(2.0), scale=scale)
+        score_id = soft_eq(support, torch.tensor(1.0), torch.tensor(1.0), scale=scale)
+        assert (
+            torch.abs(score_diff - score_id) < 1e-10
+        ), "soft_eq does not approach true answer as scale approaches infinity"
+
+    # condition iii: 0 just in case true identity
+    true_identity = soft_eq(support, torch.tensor(1.0), torch.tensor(1.0))
+    false_identity = soft_eq(support, torch.tensor(1.0), torch.tensor(1.001))
+
+    assert true_identity == 0, "soft_eq does not yield zero on identity"
+    assert true_identity > false_identity, "soft_eq does not penalize difference"
+
+
 @pytest.mark.parametrize("plate_size", [4, 50, 200])
 @pytest.mark.parametrize("event_shape", [(), (3,), (3, 2)], ids=str)
 def test_consequent_differs(plate_size, event_shape):

--- a/tests/explainable/test_ops.py
+++ b/tests/explainable/test_ops.py
@@ -1,6 +1,7 @@
 import pyro
 import pyro.distributions as dist
-import pyro.distributions.constraints as constraints
+
+# import pyro.distributions.constraints as constraints
 import pyro.infer
 import pytest
 import torch
@@ -10,7 +11,7 @@ from chirho.counterfactual.handlers import (
     SingleWorldCounterfactual,
 )
 from chirho.counterfactual.ops import split
-from chirho.explainable.ops import consequent_differs, preempt, soft_neq
+from chirho.explainable.ops import consequent_differs, preempt  # , soft_eq
 from chirho.indexed.ops import IndexSet, gather
 from chirho.observational.handlers.condition import Factors
 
@@ -38,59 +39,59 @@ def test_preempt_op_singleworld():
     assert torch.all(tr.nodes["y_"]["value"] == 1.0)
 
 
-def test_soft_neq_boolean():
-    support = constraints.boolean
+# def test_soft_eq_boolean():
+#     support = constraints.boolean
 
-    boolean_tensor_1 = torch.tensor([True, False, True, False])
-    boolean_tensor_2 = torch.tensor([True, True, False, False])
+#     boolean_tensor_1 = torch.tensor([True, False, True, False])
+#     boolean_tensor_2 = torch.tensor([True, True, False, False])
 
-    log_boolean_neq = soft_neq(support, boolean_tensor_1, boolean_tensor_2)
+#     log_boolean_eq = soft_eq(support, boolean_tensor_1, boolean_tensor_2)
 
-    real_tensor_1 = torch.tensor([1.0, 0.0, 1.0, 0.0])
-    real_tensor_2 = torch.tensor([1.0, 1.0, 0.0, 0.0])
+#     real_tensor_1 = torch.tensor([1.0, 0.0, 1.0, 0.0])
+#     real_tensor_2 = torch.tensor([1.0, 1.0, 0.0, 0.0])
 
-    real_boolean_neq = soft_neq(support, real_tensor_1, real_tensor_2)
+#     real_boolean_eq = soft_eq(support, real_tensor_1, real_tensor_2)
 
-    with pytest.raises(
-        TypeError, match="Boolean tensors have to be of the same dtype."
-    ):
-        soft_neq(support, boolean_tensor_1, real_tensor_1)
+#     with pytest.raises(
+#         TypeError, match="Boolean tensors have to be of the same dtype."
+#     ):
+#         soft_eq(support, boolean_tensor_1, real_tensor_1)
 
-    assert torch.equal(log_boolean_neq, real_boolean_neq) and torch.equal(
-        real_boolean_neq, torch.tensor([-1e8, 0.0, 0.0, -1e8])
-    )
-
-
-def test_soft_neq_positive():
-    t1 = torch.arange(0, 50, 1)
-    t2 = t1 + 3
-    pos_neq = soft_neq(constraints.positive, t1, t2, scale=0.1)
-    assert torch.allclose(
-        pos_neq, pos_neq[0], rtol=0.001
-    ), "soft_neq is not a function of the absolute distance between the two original values"
+#     assert torch.equal(log_boolean_eq, real_boolean_eq) and torch.equal(
+#         real_boolean_eq, torch.tensor([0.0, -1e8, -1e8, 0.0])
+#     )
 
 
-def test_soft_neq_interval():
-    t1 = torch.arange(0, 8, 0.1)
-    t2 = t1 + 1
-    t2b = t1 + 2
-    inter_neq = soft_neq(constraints.interval(0, 10), t1, t2, scale=100)
-    inter_neq_b = soft_neq(constraints.interval(0, 10), t1, t2b, scale=100)
+# def test_soft_eq_positive():
+#     t1 = torch.arange(0, 50, 1)
+#     t2 = t1 + 3
+#     pos_eq = soft_eq(constraints.positive, t1, t2, scale=0.1)
+#     assert torch.allclose(
+#         pos_eq, pos_eq[0], rtol=0.001
+#     ), "soft_eq is not a function of the absolute distance between the two original values"
 
-    assert torch.all(
-        inter_neq_b > inter_neq
-    ), "soft_neq is not monotonic in the absolute distance between the two original values"
 
-    assert torch.allclose(
-        inter_neq, inter_neq[0], rtol=0.001
-    ), "soft_neq is not a function of the absolute distance between the two original values"
+# def test_soft_eq_interval():
+#     t1 = torch.arange(0, 8, 0.1)
+#     t2 = t1 + 1
+#     t2b = t1 + 2
+#     inter_eq = soft_eq(constraints.interval(0, 10), t1, t2, scale=100)
+#     inter_eq_b = soft_eq(constraints.interval(0, 10), t1, t2b, scale=100)
 
-    inter_neq_10 = soft_neq(constraints.interval(0, 10), t1, t2, scale=100)
-    inter_neq_20 = soft_neq(constraints.interval(-10, 10), t1, t2b, scale=100)
+#     assert torch.all(
+#         inter_eq_b < inter_eq
+#     ), "soft_eq is not monotonic in the absolute distance between the two original values"
 
-    assert torch.allclose(
-        inter_neq_10, inter_neq_20, rtol=0.001
-    ), "soft_neq does not scale with interval"
+#     assert torch.allclose(
+#         inter_eq, inter_eq[0], rtol=0.001
+#     ), "soft_eq is not a function of the absolute distance between the two original values"
+
+#     inter_eq_10 = soft_eq(constraints.interval(0, 10), t1, t2, scale=100)
+#     inter_eq_20 = soft_eq(constraints.interval(-10, 10), t1, t2b, scale=100)
+
+#     assert torch.allclose(
+#         inter_eq_10, inter_eq_20, rtol=0.001
+#     ), "soft_eq does not scale with interval"
 
 
 @pytest.mark.parametrize("plate_size", [4, 50, 200])

--- a/tests/explainable/test_ops.py
+++ b/tests/explainable/test_ops.py
@@ -1,7 +1,6 @@
 import pyro
 import pyro.distributions as dist
-
-# import pyro.distributions.constraints as constraints
+import pyro.distributions.constraints as constraints
 import pyro.infer
 import pytest
 import torch
@@ -11,7 +10,7 @@ from chirho.counterfactual.handlers import (
     SingleWorldCounterfactual,
 )
 from chirho.counterfactual.ops import split
-from chirho.explainable.ops import consequent_differs, preempt  # , soft_eq
+from chirho.explainable.ops import consequent_differs, preempt, soft_eq
 from chirho.indexed.ops import IndexSet, gather
 from chirho.observational.handlers.condition import Factors
 
@@ -39,59 +38,63 @@ def test_preempt_op_singleworld():
     assert torch.all(tr.nodes["y_"]["value"] == 1.0)
 
 
-# def test_soft_eq_boolean():
-#     support = constraints.boolean
+def test_soft_eq_boolean():
+    support = constraints.boolean
 
-#     boolean_tensor_1 = torch.tensor([True, False, True, False])
-#     boolean_tensor_2 = torch.tensor([True, True, False, False])
+    boolean_tensor_1 = torch.tensor([True, False, True, False])
+    boolean_tensor_2 = torch.tensor([True, True, False, False])
 
-#     log_boolean_eq = soft_eq(support, boolean_tensor_1, boolean_tensor_2)
+    log_boolean_eq = soft_eq(support, boolean_tensor_1, boolean_tensor_2)
 
-#     real_tensor_1 = torch.tensor([1.0, 0.0, 1.0, 0.0])
-#     real_tensor_2 = torch.tensor([1.0, 1.0, 0.0, 0.0])
+    real_tensor_1 = torch.tensor([1.0, 0.0, 1.0, 0.0])
+    real_tensor_2 = torch.tensor([1.0, 1.0, 0.0, 0.0])
 
-#     real_boolean_eq = soft_eq(support, real_tensor_1, real_tensor_2)
+    real_boolean_eq = soft_eq(support, real_tensor_1, real_tensor_2)
 
-#     with pytest.raises(
-#         TypeError, match="Boolean tensors have to be of the same dtype."
-#     ):
-#         soft_eq(support, boolean_tensor_1, real_tensor_1)
+    with pytest.raises(
+        TypeError, match="Boolean tensors have to be of the same dtype."
+    ):
+        soft_eq(support, boolean_tensor_1, real_tensor_1)
 
-#     assert torch.equal(log_boolean_eq, real_boolean_eq) and torch.equal(
-#         real_boolean_eq, torch.tensor([0.0, -1e8, -1e8, 0.0])
-#     )
-
-
-# def test_soft_eq_positive():
-#     t1 = torch.arange(0, 50, 1)
-#     t2 = t1 + 3
-#     pos_eq = soft_eq(constraints.positive, t1, t2, scale=0.1)
-#     assert torch.allclose(
-#         pos_eq, pos_eq[0], rtol=0.001
-#     ), "soft_eq is not a function of the absolute distance between the two original values"
+    assert torch.equal(log_boolean_eq, real_boolean_eq) and torch.equal(
+        real_boolean_eq, torch.tensor([0.0, -1e8, -1e8, 0.0])
+    )
 
 
-# def test_soft_eq_interval():
-#     t1 = torch.arange(0, 8, 0.1)
-#     t2 = t1 + 1
-#     t2b = t1 + 2
-#     inter_eq = soft_eq(constraints.interval(0, 10), t1, t2, scale=100)
-#     inter_eq_b = soft_eq(constraints.interval(0, 10), t1, t2b, scale=100)
+def test_soft_eq_positive():
+    t1 = torch.arange(0, 50, 1)
+    t2 = t1 + 3
+    pos_eq = soft_eq(constraints.positive, t1, t2)
+    assert torch.allclose(
+        pos_eq, pos_eq[0], rtol=0.001
+    ), "soft_eq is not a function of the absolute distance between the two original values"
 
-#     assert torch.all(
-#         inter_eq_b < inter_eq
-#     ), "soft_eq is not monotonic in the absolute distance between the two original values"
 
-#     assert torch.allclose(
-#         inter_eq, inter_eq[0], rtol=0.001
-#     ), "soft_eq is not a function of the absolute distance between the two original values"
+def test_soft_eq_interval():
+    t1 = torch.arange(0, 8, 0.1)
+    t2 = t1 + 1
+    t2b = t1 + 2
+    inter_eq = soft_eq(constraints.interval(0, 10), t1, t2)
+    inter_eq_b = soft_eq(constraints.interval(0, 10), t1, t2b)
 
-#     inter_eq_10 = soft_eq(constraints.interval(0, 10), t1, t2, scale=100)
-#     inter_eq_20 = soft_eq(constraints.interval(-10, 10), t1, t2b, scale=100)
+    assert torch.all(
+        inter_eq_b < inter_eq
+    ), "soft_eq is not monotonic in the absolute distance between the two original values"
 
-#     assert torch.allclose(
-#         inter_eq_10, inter_eq_20, rtol=0.001
-#     ), "soft_eq does not scale with interval"
+    assert torch.allclose(
+        inter_eq, inter_eq[0], rtol=0.001
+    ), "soft_eq is not a function of the absolute distance between the two original values"
+
+    assert torch.allclose(
+        inter_eq_b, inter_eq_b[0], rtol=0.001
+    ), "soft_eq is not a function of the absolute distance between the two original values"
+
+    inter_eq_10 = soft_eq(constraints.interval(0, 10), t1, t2)
+    inter_eq_20 = soft_eq(constraints.interval(-10, 10), t1, t2b)
+
+    assert torch.allclose(
+        inter_eq_10, inter_eq_20, rtol=0.001
+    ), "soft_eq does noh interval"
 
 
 @pytest.mark.parametrize("plate_size", [4, 50, 200])

--- a/tests/explainable/test_ops.py
+++ b/tests/explainable/test_ops.py
@@ -12,7 +12,8 @@ from chirho.counterfactual.handlers import (
     SingleWorldCounterfactual,
 )
 from chirho.counterfactual.ops import split
-from chirho.explainable.ops import consequent_differs, preempt, soft_eq, soft_neq
+from chirho.explainable.internals.defaults import soft_eq, soft_neq
+from chirho.explainable.ops import consequent_differs, preempt
 from chirho.indexed.ops import IndexSet, gather
 from chirho.observational.handlers.condition import Factors
 


### PR DESCRIPTION
When all consequent variables are binary, the factor applied to the consequent variable can only be non-equality (`c_observed != c_alternative`). However, when the consequent variables are not binary, different approximations of this potentially measure-0 condition may lead to different conclusions, and it is not always obvious which one to choose.

A common choice in work on counterfactual explanations in machine learning is a simple choice of distance measure or divergence that depends on the support of the consequent. To capture this, we define a support-dependent helper function `soft_neq`  to be used in the helper function `consequent_differs`, and an analogous `soft_eq` function to be used in the antecedent proposal evaluation.

The key constraints we want the functions to satisfy are counterparts of the predicate relaxation conditions as introduced in  "Predicate exchange..." by Tavares et al. Additional constraints related to the more general behavior of the `explainable` module are formulated in `tests.explainable.test_ops`.