### PR TITLE
Replace some `torch.vmap` usage with a hand-vectorized `BatchedNMCLogPredictiveLikelihood`

### DIFF
--- a/chirho/observational/handlers/condition.py
+++ b/chirho/observational/handlers/condition.py
@@ -1,4 +1,4 @@
-from typing import Callable, Generic, Hashable, Mapping, TypeVar, Union
+from typing import Callable, Generic, Mapping, TypeVar, Union
 
 import pyro
 import torch
@@ -61,8 +61,9 @@ class Observations(Generic[T], ObserveNameMessenger):
     Can be used as a drop-in replacement for :func:`pyro.condition` that supports
     a richer set of observational data types and enables counterfactual inference.
     """
+    data: Mapping[str, AtomicObservation[T]]
 
-    def __init__(self, data: Mapping[Hashable, AtomicObservation[T]]):
+    def __init__(self, data: Mapping[str, AtomicObservation[T]]):
         self.data = data
         super().__init__()
 

--- a/chirho/observational/handlers/condition.py
+++ b/chirho/observational/handlers/condition.py
@@ -4,7 +4,7 @@ import pyro
 import torch
 
 from chirho.observational.internals import ObserveNameMessenger
-from chirho.observational.ops import AtomicObservation, observe
+from chirho.observational.ops import Observation, observe
 
 T = TypeVar("T")
 R = Union[float, torch.Tensor]
@@ -62,9 +62,9 @@ class Observations(Generic[T], ObserveNameMessenger):
     a richer set of observational data types and enables counterfactual inference.
     """
 
-    data: Mapping[str, AtomicObservation[T]]
+    data: Mapping[str, Observation[T]]
 
-    def __init__(self, data: Mapping[str, AtomicObservation[T]]):
+    def __init__(self, data: Mapping[str, Observation[T]]):
         self.data = data
         super().__init__()
 

--- a/chirho/observational/handlers/condition.py
+++ b/chirho/observational/handlers/condition.py
@@ -61,6 +61,7 @@ class Observations(Generic[T], ObserveNameMessenger):
     Can be used as a drop-in replacement for :func:`pyro.condition` that supports
     a richer set of observational data types and enables counterfactual inference.
     """
+
     data: Mapping[str, AtomicObservation[T]]
 
     def __init__(self, data: Mapping[str, AtomicObservation[T]]):

--- a/chirho/robust/internals/linearize.py
+++ b/chirho/robust/internals/linearize.py
@@ -159,11 +159,6 @@ def linearize(
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> ParamDict:
-        if batched_log_prob.max_plate_nesting is None:
-            batched_log_prob.max_plate_nesting = guess_max_plate_nesting(
-                model, guide, *args, **kwargs
-            )
-
         with torch.no_grad():
             data: Point[T] = predictive(*args, **kwargs)
             data = {k: data[k] for k in points.keys()}

--- a/chirho/robust/internals/linearize.py
+++ b/chirho/robust/internals/linearize.py
@@ -8,7 +8,6 @@ from typing_extensions import Concatenate, ParamSpec
 from chirho.robust.internals.predictive import BatchedNMCLogPredictiveLikelihood
 from chirho.robust.internals.utils import (
     ParamDict,
-    guess_max_plate_nesting,
     make_flatten_unflatten,
     make_functional_call,
     reset_rng_state,

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -149,7 +149,7 @@ class NMCLogPredictiveLikelihood(Generic[P, T], torch.nn.Module):
             masked_guide,
             *args,
             num_samples=self.num_samples,
-            max_plate_nesting=self.max_plate_nesting,(optional)
+            max_plate_nesting=self.max_plate_nesting
             **kwargs,
         )[0]
         return torch.logsumexp(log_weights, dim=0) - math.log(self.num_samples)
@@ -202,7 +202,7 @@ def BatchedNMCLogPredictiveLikelihood(
     mc_plate_name: str = "__particles_mc",
 ) -> Callable[Concatenate[Mapping[str, torch.Tensor], P], torch.Tensor]:
     # TODO factorize into composition of general helper functions:
-    #   - (optional) guess max_plate_nesting
+    #   - (optional) infer max_plate_nesting from model and guide
     #   - construct predictive model from model and guide
     #   - batch observations with BatchedObservations
     #   - batch particles with pyro.plate

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -284,7 +284,6 @@ class BatchedNMCLogPredictiveLikelihood(Generic[P], torch.nn.Module):
         self.num_samples = num_samples
         self.data_plate_name = data_plate_name
         self.mc_plate_name = mc_plate_name
-        self._plate_names: List[str] = [mc_plate_name, data_plate_name]
 
     def _batched_predictive_model(
         self, data: Mapping[str, torch.Tensor], *args: P.args, **kwargs: P.kwargs
@@ -309,7 +308,10 @@ class BatchedNMCLogPredictiveLikelihood(Generic[P], torch.nn.Module):
         )
         model_trace, guide_trace = get_nmc_traces(data, *args, **kwargs)
 
-        wds = "".join(model_trace.plate_to_symbol[p] for p in self._plate_names)
+        wds = "".join(
+            model_trace.plate_to_symbol[p]
+            for p in [self.mc_plate_name, self.data_plate_name]
+        )
 
         log_weights = 0.0
         for site in model_trace.nodes.values():

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -141,7 +141,7 @@ class BatchedNMCLogPredictiveLikelihood(Generic[P, T], torch.nn.Module):
                 continue
             site_log_prob = site["log_prob"]
             for f in site["cond_indep_stack"]:
-                if f.vectorized and f.name not in plate_name_to_dim:
+                if f.dim is not None and f.name not in plate_name_to_dim:
                     site_log_prob = site_log_prob.sum(f.dim, keepdim=True)
             log_weights += site_log_prob
 
@@ -150,7 +150,7 @@ class BatchedNMCLogPredictiveLikelihood(Generic[P, T], torch.nn.Module):
                 continue
             site_log_prob = site["log_prob"]
             for f in site["cond_indep_stack"]:
-                if f.vectorized and f.name not in plate_name_to_dim:
+                if f.dim is not None and f.name not in plate_name_to_dim:
                     site_log_prob = site_log_prob.sum(f.dim, keepdim=True)
             log_weights -= site_log_prob
 

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -242,7 +242,7 @@ def get_importance_traces(
                 guide_trace.pack_tensors()
                 model_trace.pack_tensors(guide_trace.plate_to_symbol)
             return model_trace, guide_trace
-        else:  # use the prior as a guide, but don't run model twice
+        else:  # use prior as default guide, but don't run model twice
             model_trace, _ = pyro.infer.enum.get_importance_trace(
                 "flat", math.inf, model, lambda *_, **__: None, args, kwargs
             )

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -131,11 +131,12 @@ class BatchedNMCLogPredictiveLikelihood(Generic[P, T], torch.nn.Module):
         with IndexPlatesMessenger(first_available_dim=self._first_available_dim):
             model_trace, guide_trace = get_nmc_traces(*args, **kwargs)
             index_plates = get_index_plates()
-            plate_name_to_dim = collections.OrderedDict(
-                (index_plates[p].name, index_plates[p].dim)
-                for p in [self._mc_plate_name, self._data_plate_name]
-                if p in index_plates
-            )
+
+        plate_name_to_dim = collections.OrderedDict(
+            (index_plates[p].name, index_plates[p].dim)
+            for p in [self._mc_plate_name, self._data_plate_name]
+            if p in index_plates
+        )
 
         log_weights = typing.cast(torch.Tensor, 0.0)
         for site in model_trace.nodes.values():

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -103,7 +103,11 @@ class BatchedObservations(Generic[T], Observations[T]):
         super()._pyro_observe(msg)
         if msg["kwargs"]["name"] in self.data:
             rv, obs = msg["args"]
-            event_dim = len(rv.event_shape)
+            event_dim = (
+                len(rv.event_shape)
+                if hasattr(rv, "event_shape")
+                else msg["kwargs"].get("event_dim", 0)
+            )
             batch_obs = unbind_leftmost_dim(obs, self.name, event_dim=event_dim)
             msg["args"] = (rv, batch_obs)
 

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -282,8 +282,7 @@ class BatchedNMCLogPredictiveLikelihood(Generic[P, T], torch.nn.Module):
                 [site["packed"]["log_prob"]],
             )
 
-        assert isinstance(log_weights, torch.Tensor)
-        assert len(log_weights.shape) == 2 and log_weights.shape[0] == self.num_samples
-
-        log_weights = torch.logsumexp(log_weights, dim=0) - math.log(self.num_samples)
-        return log_weights
+        assert isinstance(log_weights, torch.Tensor)  # DEBUG
+        assert len(log_weights.shape) == 2  # DEBUG
+        assert log_weights.shape[0] == self.num_samples  # DEBUG
+        return torch.logsumexp(log_weights, dim=0) - math.log(self.num_samples)

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -126,8 +126,8 @@ class BatchedObservations(Observations[torch.Tensor]):
 
 
 class BatchedLatents(pyro.poutine.messenger.Messenger):
-    name: str
     num_particles: int
+    name: str
 
     def __init__(self, num_particles: int, *, name: str = "__particles_mc"):
         assert num_particles > 0

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -174,18 +174,15 @@ class BatchedObservations(Observations[torch.Tensor]):
         old_datum, event_dim = self.data[msg["name"]], len(msg["fn"].event_shape)
 
         try:
-            if not msg["infer"].get("_do_not_observe", None):
-                new_datum: torch.Tensor = torch.as_tensor(old_datum)
-                with self.plate:  # enter plate context here to ensure plate.dim is set
-                    while self.plate.dim - event_dim < -len(new_datum.shape):
-                        new_datum = new_datum[None]
-                    if new_datum.shape[0] == 1:
-                        new_datum = torch.transpose(
-                            new_datum, -len(old_datum.shape), self.plate.dim - event_dim
-                        )
-                    self.data[msg["name"]] = new_datum
-                    return super()._pyro_sample(msg)
-            else:
+            new_datum: torch.Tensor = torch.as_tensor(old_datum)
+            with self.plate:  # enter plate context here to ensure plate.dim is set
+                while self.plate.dim - event_dim < -len(new_datum.shape):
+                    new_datum = new_datum[None]
+                if new_datum.shape[0] == 1 and old_datum.shape[0] != 1:
+                    new_datum = torch.transpose(
+                        new_datum, -len(old_datum.shape), self.plate.dim - event_dim
+                    )
+                self.data[msg["name"]] = new_datum
                 return super()._pyro_sample(msg)
         finally:
             self.data[msg["name"]] = old_datum

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -203,9 +203,9 @@ def BatchedNMCLogPredictiveLikelihood(
 ) -> Callable[Concatenate[Mapping[str, torch.Tensor], P], torch.Tensor]:
     # TODO factorize into composition of general helper functions:
     #   - construct predictive model from model and guide
+    #   - guess max_plate_nesting
     #   - batch observations with BatchedObservations
     #   - batch particles with pyro.plate
-    #   - (optional) guess max_plate_nesting
     #   - compute batched log weights over batch plate set
     #   - logsumexp over particle plate
 

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -201,6 +201,14 @@ def BatchedNMCLogPredictiveLikelihood(
     data_plate_name: str = "__particles_data",
     mc_plate_name: str = "__particles_mc",
 ) -> Callable[Concatenate[Mapping[str, torch.Tensor], P], torch.Tensor]:
+    # TODO factorize into composition of general helper functions:
+    #   - construct predictive model from model and guide
+    #   - batch observations with BatchedObservations
+    #   - batch particles with pyro.plate
+    #   - (optional) guess max_plate_nesting
+    #   - compute batched log weights over batch plate set
+    #   - logsumexp over particle plate
+
     def _fn(
         data: Mapping[str, torch.Tensor], *args: P.args, **kwargs: P.kwargs
     ) -> torch.Tensor:

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -149,7 +149,7 @@ class NMCLogPredictiveLikelihood(Generic[P, T], torch.nn.Module):
             masked_guide,
             *args,
             num_samples=self.num_samples,
-            max_plate_nesting=self.max_plate_nesting
+            max_plate_nesting=self.max_plate_nesting,
             **kwargs,
         )[0]
         return torch.logsumexp(log_weights, dim=0) - math.log(self.num_samples)

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -143,7 +143,7 @@ class BatchedNMCLogPredictiveLikelihood(Generic[P, T], torch.nn.Module):
             for f in site["cond_indep_stack"]:
                 if f.dim is not None and f.name not in plate_name_to_dim:
                     site_log_prob = site_log_prob.sum(f.dim, keepdim=True)
-            log_weights += site_log_prob
+            log_weights = log_weights + site_log_prob
 
         for site in guide_trace.nodes.values():
             if site["type"] != "sample":
@@ -152,7 +152,7 @@ class BatchedNMCLogPredictiveLikelihood(Generic[P, T], torch.nn.Module):
             for f in site["cond_indep_stack"]:
                 if f.dim is not None and f.name not in plate_name_to_dim:
                     site_log_prob = site_log_prob.sum(f.dim, keepdim=True)
-            log_weights -= site_log_prob
+            log_weights = log_weights - site_log_prob
 
         # sum out particle dimension and discard
         if self._mc_plate_name in index_plates:

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -240,7 +240,7 @@ def get_importance_traces(
                 guide_trace.pack_tensors()
                 model_trace.pack_tensors(guide_trace.plate_to_symbol)
             return model_trace, guide_trace
-        else:
+        else:  # use the prior as a guide, but don't run model twice
             model_trace, _ = pyro.infer.enum.get_importance_trace(
                 "flat", max_plate_nesting, model, lambda *_, **__: None, args, kwargs
             )

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -8,11 +8,12 @@ import torch
 from typing_extensions import ParamSpec
 
 from chirho.indexed.handlers import IndexPlatesMessenger
-from chirho.indexed.ops import get_index_plates
+from chirho.indexed.ops import get_index_plates, indices_of
+from chirho.observational.handlers.condition import Observations
 from chirho.robust.internals.utils import (
-    BatchedLatents,
-    BatchedObservations,
     get_importance_traces,
+    site_is_delta,
+    unbind_leftmost_dim,
 )
 from chirho.robust.ops import Point
 
@@ -22,6 +23,82 @@ P = ParamSpec("P")
 Q = ParamSpec("Q")
 S = TypeVar("S")
 T = TypeVar("T")
+
+
+class BatchedLatents(pyro.poutine.messenger.Messenger):
+    """
+    Effect handler that adds a fresh batch dimension to all latent ``sample`` sites.
+    Similar to wrapping a Pyro model in a ``pyro.plate`` context, but uses the machinery
+    in ``chirho.indexed`` to automatically allocate and track the fresh batch dimension
+    based on the ``name`` argument to ``BatchedLatents`` .
+
+    .. warning:: Must be used in conjunction with :class:`~chirho.indexed.handlers.IndexPlatesMessenger` .
+
+    :param int num_particles: Number of particles to use for parallelization.
+    :param str name: Name of the fresh batch dimension.
+    """
+
+    num_particles: int
+    name: str
+
+    def __init__(self, num_particles: int, *, name: str = "__particles_mc"):
+        assert num_particles > 0
+        assert len(name) > 0
+        self.num_particles = num_particles
+        self.name = name
+        super().__init__()
+
+    def _pyro_sample(self, msg: dict) -> None:
+        if (
+            self.num_particles > 1
+            and msg["value"] is None
+            and not pyro.poutine.util.site_is_factor(msg)
+            and not pyro.poutine.util.site_is_subsample(msg)
+            and not site_is_delta(msg)
+            and self.name not in indices_of(msg["fn"])
+        ):
+            msg["fn"] = unbind_leftmost_dim(
+                msg["fn"].expand((1,) + msg["fn"].batch_shape),
+                self.name,
+                size=self.num_particles,
+            )
+
+
+class BatchedObservations(Generic[T], Observations[T]):
+    """
+    Effect handler that takes a dictionary of observation values for ``sample`` sites
+    that are assumed to be batched along their leftmost dimension, adds a fresh named
+    dimension using the machinery in ``chirho.indexed``, and reshapes the observation
+    values so that the new ``chirho.observational.observe`` sites are batched along
+    the fresh named dimension.
+
+    Useful in combination with ``pyro.infer.Predictive`` which returns a dictionary
+    of values whose leftmost dimension is a batch dimension over independent samples.
+
+    .. warning:: Must be used in conjunction with :class:`~chirho.indexed.handlers.IndexPlatesMessenger` .
+
+    :param Point[T] data: Dictionary of observation values.
+    :param str name: Name of the fresh batch dimension.
+    """
+
+    name: str
+
+    def __init__(self, data: Point[T], *, name: str = "__particles_data"):
+        assert len(name) > 0
+        self.name = name
+        super().__init__(data)
+
+    def _pyro_observe(self, msg: dict) -> None:
+        super()._pyro_observe(msg)
+        if msg["kwargs"]["name"] in self.data:
+            rv, obs = msg["args"]
+            event_dim = (
+                len(rv.event_shape)
+                if hasattr(rv, "event_shape")
+                else msg["kwargs"].get("event_dim", 0)
+            )
+            batch_obs = unbind_leftmost_dim(obs, self.name, event_dim=event_dim)
+            msg["args"] = (rv, batch_obs)
 
 
 class PredictiveModel(Generic[P, T], torch.nn.Module):

--- a/chirho/robust/internals/predictive.py
+++ b/chirho/robust/internals/predictive.py
@@ -149,7 +149,7 @@ class NMCLogPredictiveLikelihood(Generic[P, T], torch.nn.Module):
             masked_guide,
             *args,
             num_samples=self.num_samples,
-            max_plate_nesting=self.max_plate_nesting,
+            max_plate_nesting=self.max_plate_nesting,(optional)
             **kwargs,
         )[0]
         return torch.logsumexp(log_weights, dim=0) - math.log(self.num_samples)
@@ -202,8 +202,8 @@ def BatchedNMCLogPredictiveLikelihood(
     mc_plate_name: str = "__particles_mc",
 ) -> Callable[Concatenate[Mapping[str, torch.Tensor], P], torch.Tensor]:
     # TODO factorize into composition of general helper functions:
+    #   - (optional) guess max_plate_nesting
     #   - construct predictive model from model and guide
-    #   - guess max_plate_nesting
     #   - batch observations with BatchedObservations
     #   - batch particles with pyro.plate
     #   - compute batched log weights over batch plate set

--- a/chirho/robust/internals/utils.py
+++ b/chirho/robust/internals/utils.py
@@ -6,6 +6,9 @@ import pyro
 import torch
 from typing_extensions import Concatenate, ParamSpec
 
+from chirho.indexed.handlers import add_indices
+from chirho.indexed.ops import IndexSet, get_index_plates
+
 P = ParamSpec("P")
 Q = ParamSpec("Q")
 S = TypeVar("S")
@@ -106,3 +109,45 @@ def reset_rng_state(rng_state: T):
         yield pyro.util.set_rng_state(rng_state)
     finally:
         pyro.util.set_rng_state(prev_rng_state)
+
+
+@functools.singledispatch
+def unbind_leftmost_dim(v, name: str, size: int = 1, **kwargs):
+    raise NotImplementedError
+
+
+@unbind_leftmost_dim.register
+def _unbind_leftmost_dim_tensor(
+    v: torch.Tensor, name: str, size: int = 1, *, event_dim: int = 0
+) -> torch.Tensor:
+    size = max(size, v.shape[0])
+    v = v.expand((size,) + v.shape[1:])
+
+    if name not in get_index_plates():
+        add_indices(IndexSet(**{name: set(range(size))}))
+
+    new_dim: int = get_index_plates()[name].dim
+    orig_shape = v.shape
+    while new_dim - event_dim < -len(v.shape):
+        v = v[None]
+    if v.shape[0] == 1 and orig_shape[0] != 1:
+        v = torch.transpose(v, -len(orig_shape), new_dim - event_dim)
+    return v
+
+
+@unbind_leftmost_dim.register
+def _unbind_leftmost_dim_distribution(
+    v: pyro.distributions.Distribution, name: str, size: int = 1, **kwargs
+) -> pyro.distributions.Distribution:
+    size = max(size, v.batch_shape[0])
+    if v.batch_shape[0] != 1:
+        raise NotImplementedError("Cannot freely reshape distribution")
+
+    if name not in get_index_plates():
+        add_indices(IndexSet(**{name: set(range(size))}))
+
+    new_dim: int = get_index_plates()[name].dim
+    orig_shape = v.batch_shape
+
+    new_shape = (size,) + (1,) * (-new_dim - len(orig_shape)) + orig_shape[1:]
+    return v.expand(new_shape)

--- a/chirho/robust/internals/utils.py
+++ b/chirho/robust/internals/utils.py
@@ -217,12 +217,13 @@ class BatchedLatents(pyro.poutine.messenger.Messenger):
         super().__init__()
 
     def _pyro_sample(self, msg: dict) -> None:
-        if pyro.poutine.util.site_is_factor(msg) or pyro.poutine.util.site_is_subsample(
-            msg
+        if (
+            self.num_particles > 1
+            and msg["value"] is None
+            and not pyro.poutine.util.site_is_factor(msg)
+            and not pyro.poutine.util.site_is_subsample(msg)
+            and self.name not in indices_of(msg["fn"])
         ):
-            return
-
-        if self.num_particles > 1 and self.name not in indices_of(msg["fn"]):
             msg["fn"] = unbind_leftmost_dim(
                 msg["fn"].expand((1,) + msg["fn"].batch_shape),
                 self.name,

--- a/tests/robust/test_internals_compositions.py
+++ b/tests/robust/test_internals_compositions.py
@@ -12,11 +12,8 @@ from chirho.robust.internals.linearize import (
     make_empirical_fisher_vp,
 )
 from chirho.robust.internals.predictive import (
-    BatchedNMCLogPredictiveLikelihood,
     BatchedObservations,
     NMCLogPredictiveLikelihood,
-    PredictiveFunctional,
-    PredictiveModel,
 )
 from chirho.robust.internals.utils import make_functional_call, reset_rng_state
 
@@ -123,8 +120,9 @@ def test_nmc_likelihood_seeded(link_fn):
     assert torch.allclose(fvp(v)["guide.loc_b"], fvp(v)["guide.loc_b"])
 
 
-def test_batched_observations():
-    max_plate_nesting = 1
+@pytest.mark.parametrize("pad_dim", [0, 1, 2])
+def test_batched_observations(pad_dim: int):
+    max_plate_nesting = 1 + pad_dim
     plate_name = "__dummy_plate__"
     model = SimpleModel()
     guide = SimpleGuide()

--- a/tests/robust/test_internals_compositions.py
+++ b/tests/robust/test_internals_compositions.py
@@ -11,13 +11,12 @@ from chirho.robust.internals.linearize import (
     conjugate_gradient_solve,
     make_empirical_fisher_vp,
 )
-from chirho.robust.internals.predictive import BatchedNMCLogPredictiveLikelihood
-from chirho.robust.internals.utils import (
+from chirho.robust.internals.predictive import (
     BatchedLatents,
+    BatchedNMCLogPredictiveLikelihood,
     BatchedObservations,
-    make_functional_call,
-    reset_rng_state,
 )
+from chirho.robust.internals.utils import make_functional_call, reset_rng_state
 
 from .robust_fixtures import SimpleGuide, SimpleModel
 

--- a/tests/robust/test_internals_compositions.py
+++ b/tests/robust/test_internals_compositions.py
@@ -12,10 +12,9 @@ from chirho.robust.internals.linearize import (
     make_empirical_fisher_vp,
 )
 from chirho.robust.internals.predictive import (
-    BatchedObservations,
     NMCLogPredictiveLikelihood,
 )
-from chirho.robust.internals.utils import make_functional_call, reset_rng_state
+from chirho.robust.internals.utils import BatchedObservations, make_functional_call, reset_rng_state
 
 from .robust_fixtures import SimpleGuide, SimpleModel
 

--- a/tests/robust/test_performance.py
+++ b/tests/robust/test_performance.py
@@ -1,0 +1,178 @@
+import math
+import time
+import warnings
+from functools import partial
+from typing import Any, Callable, Container, Generic, Optional, TypeVar
+
+import pyro
+import pytest
+import torch
+from typing_extensions import ParamSpec
+
+from chirho.indexed.handlers import DependentMaskMessenger
+from chirho.observational.handlers import condition
+from chirho.robust.internals.linearize import make_empirical_fisher_vp
+from chirho.robust.internals.predictive import BatchedNMCLogPredictiveLikelihood
+from chirho.robust.internals.utils import guess_max_plate_nesting, make_functional_call
+from chirho.robust.ops import Point
+
+from .robust_fixtures import SimpleGuide, SimpleModel
+
+pyro.settings.set(module_local_params=True)
+
+P = ParamSpec("P")
+Q = ParamSpec("Q")
+S = TypeVar("S")
+T = TypeVar("T")
+
+
+class _UnmaskNamedSites(DependentMaskMessenger):
+    names: Container[str]
+
+    def __init__(self, names: Container[str]):
+        self.names = names
+
+    def get_mask(
+        self,
+        dist: pyro.distributions.Distribution,
+        value: Optional[torch.Tensor],
+        device: torch.device = torch.device("cpu"),
+        name: Optional[str] = None,
+    ) -> torch.Tensor:
+        return torch.tensor(name is None or name in self.names, device=device)
+
+
+class OldNMCLogPredictiveLikelihood(Generic[P, T], torch.nn.Module):
+    model: Callable[P, Any]
+    guide: Callable[P, Any]
+    num_samples: int
+    max_plate_nesting: Optional[int]
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        guide: torch.nn.Module,
+        *,
+        num_samples: int = 1,
+        max_plate_nesting: Optional[int] = None,
+    ):
+        super().__init__()
+        self.model = model
+        self.guide = guide
+        self.num_samples = num_samples
+        self.max_plate_nesting = max_plate_nesting
+
+    def forward(
+        self, data: Point[T], *args: P.args, **kwargs: P.kwargs
+    ) -> torch.Tensor:
+        if self.max_plate_nesting is None:
+            self.max_plate_nesting = guess_max_plate_nesting(
+                self.model, self.guide, *args, **kwargs
+            )
+            warnings.warn(
+                "Since max_plate_nesting is not specified, \
+                the first call to NMCLogPredictiveLikelihood will not be seeded properly. \
+                See https://github.com/BasisResearch/chirho/pull/408"
+            )
+
+        masked_guide = pyro.poutine.mask(mask=False)(self.guide)
+        masked_model = _UnmaskNamedSites(names=set(data.keys()))(
+            condition(data=data)(self.model)
+        )
+        log_weights = pyro.infer.importance.vectorized_importance_weights(
+            masked_model,
+            masked_guide,
+            *args,
+            num_samples=self.num_samples,
+            max_plate_nesting=self.max_plate_nesting,
+            **kwargs,
+        )[0]
+        return torch.logsumexp(log_weights, dim=0) - math.log(self.num_samples)
+
+
+class SimpleMultivariateGaussianModel(pyro.nn.PyroModule):
+    def __init__(self, p):
+        super().__init__()
+        self.p = p
+
+    def forward(self):
+        loc = pyro.sample(
+            "loc", pyro.distributions.Normal(torch.zeros(self.p), 1.0).to_event(1)
+        )
+        cov_mat = torch.eye(self.p)
+        return pyro.sample("y", pyro.distributions.MultivariateNormal(loc, cov_mat))
+
+
+class SimpleMultivariateGuide(torch.nn.Module):
+    def __init__(self, p):
+        super().__init__()
+        self.loc_ = torch.nn.Parameter(torch.rand((p,)))
+        self.p = p
+
+    def forward(self):
+        return pyro.sample("loc", pyro.distributions.Normal(self.loc_, 1).to_event(1))
+
+
+model_guide_types = [
+    (
+        partial(SimpleMultivariateGaussianModel, p=500),
+        partial(SimpleMultivariateGuide, p=500),
+    ),
+    (SimpleModel, SimpleGuide),
+]
+
+
+@pytest.mark.skip(reason="This test is too slow to run on CI")
+@pytest.mark.parametrize("model_guide", model_guide_types)
+def test_empirical_fisher_vp_performance_with_likelihood(model_guide):
+    num_monte_carlo = 10000
+    model_family, guide_family = model_guide
+
+    model = model_family()
+    guide = guide_family()
+
+    model()
+    guide()
+
+    start_time = time.time()
+    data = pyro.infer.Predictive(
+        model, guide=guide, num_samples=num_monte_carlo, return_sites=["y"]
+    )()
+    end_time = time.time()
+    print("Data generation time (s): ", end_time - start_time)
+
+    log1_prob_params, func1_log_prob = make_functional_call(
+        OldNMCLogPredictiveLikelihood(model, guide, max_plate_nesting=1)
+    )
+    batched_func1_log_prob = torch.func.vmap(
+        func1_log_prob, in_dims=(None, 0), randomness="different"
+    )
+
+    log2_prob_params, func2_log_prob = make_functional_call(
+        BatchedNMCLogPredictiveLikelihood(model, guide)
+    )
+
+    fisher_hessian_vmapped = make_empirical_fisher_vp(
+        batched_func1_log_prob, log1_prob_params, data
+    )
+
+    fisher_hessian_batched = make_empirical_fisher_vp(
+        func2_log_prob, log2_prob_params, data
+    )
+
+    v = {
+        k: torch.ones_like(v) if k != "guide.loc_a" else torch.zeros_like(v)
+        for k, v in log1_prob_params.items()
+    }
+
+    func2_log_prob(log2_prob_params, data)
+
+    start_time = time.time()
+    fisher_hessian_vmapped(v)
+    end_time = time.time()
+    print("Hessian vmapped time (s): ", end_time - start_time)
+
+    start_time = time.time()
+    fisher_hessian_batched(v)
+    end_time = time.time()
+    print("Hessian manual batched time (s): ", end_time - start_time)


### PR DESCRIPTION
Addresses #463 (the remaining issue 1 from #459)
Also addresses #429

Naive usage of `torch.vmap` in `chirho.robust` has caused a number of performance issues. This PR refactors the contents of `chirho.robust.internals.predictive` to replace `NMCLogPredictiveLikelihood` with a custom `BatchedNMCLogPredictiveLikelihood` that makes use of the Pyro-specialized batching logic from `chirho.indexed`.

Remaining tasks:
- [x] Address `vmap` regression/bug causing tests to fail under `torch>=2.1.0` that passed under `torch==2.0.1`
- [x] Verify that #463 is indeed resolved by these changes
- [x] Add unit tests for new components in `chirho.robust.internals.utils`