### PR TITLE
Add full corrected one step estimator

### DIFF
--- a/chirho/robust/handlers/estimators.py
+++ b/chirho/robust/handlers/estimators.py
@@ -65,7 +65,7 @@ def one_step_corrected_estimator(
     """
     plug_in_estimator = functional(model, guide)
     correction_estimator = one_step_correction(
-        model, guide, functional, influence_fn, **influence_kwargs
+        model, guide, functional, **influence_kwargs
     )
 
     def _one_step_corrected_estimator(test_data: Point[T], *args, **kwargs) -> S:

--- a/chirho/robust/handlers/estimators.py
+++ b/chirho/robust/handlers/estimators.py
@@ -1,3 +1,4 @@
+from functools import singledispatch
 from typing import Any, Callable, Optional
 
 import torch
@@ -92,13 +93,36 @@ def one_step_corrected_estimator(
         plug_in_estimator = PredictiveFunctional(model, guide)
     else:
         plug_in_estimator = functional(model, guide)
-    correction = one_step_correction(
+    correction_estimator = one_step_correction(
         model, guide, functional, influence_fn_estimator, **influence_kwargs
     )
 
     def _one_step_corrected_estimator(test_data: Point[T], *args, **kwargs) -> S:
-        return plug_in_estimator(*args, **kwargs) + correction(
-            test_data, *args, **kwargs
-        )  # type: ignore[operator]
+        plug_in_estimate = plug_in_estimator(*args, **kwargs)
+        correction = correction_estimator(test_data, *args, **kwargs)
+        return apply_correction(plug_in_estimate, correction)
 
     return _one_step_corrected_estimator
+
+
+@singledispatch
+def apply_correction(plug_in_estimate, correction: S) -> S:
+    raise NotImplementedError
+
+
+@apply_correction.register(dict)
+def apply_correction_point(
+    plug_in_estimate: Point[T], correction: Point[T]
+) -> Point[T]:
+    assert isinstance(plug_in_estimate, dict)
+    assert isinstance(correction, dict)
+    assert set(plug_in_estimate.keys()) == set(correction.keys())
+    return {k: plug_in_estimate[k] + correction[k] for k in plug_in_estimate.keys()}
+
+
+@apply_correction.register(torch.Tensor)
+def apply_correction_tensor(
+    plug_in_estimate: torch.Tensor, correction: torch.Tensor
+) -> torch.Tensor:
+    assert isinstance(correction, torch.Tensor)
+    return plug_in_estimate + correction

--- a/chirho/robust/handlers/estimators.py
+++ b/chirho/robust/handlers/estimators.py
@@ -44,9 +44,11 @@ def one_step_corrected_estimator(
                 plug_in_estimate
             )
             flat_correction, _ = torch.utils._pytree.tree_flatten(correction)
+
             return torch.utils._pytree.tree_unflatten(
                 [a + b for a, b in zip(flat_plug_in_estimate, flat_correction)],
                 treespec,
             )
+        return _estimate_model
 
     return _corrected_functional

--- a/chirho/robust/handlers/estimators.py
+++ b/chirho/robust/handlers/estimators.py
@@ -114,7 +114,6 @@ def apply_correction(plug_in_estimate, correction: S) -> S:
 def apply_correction_point(
     plug_in_estimate: Point[T], correction: Point[T]
 ) -> Point[T]:
-    assert isinstance(plug_in_estimate, dict)
     assert isinstance(correction, dict)
     assert set(plug_in_estimate.keys()) == set(correction.keys())
     return {k: plug_in_estimate[k] + correction[k] for k in plug_in_estimate.keys()}

--- a/chirho/robust/handlers/estimators.py
+++ b/chirho/robust/handlers/estimators.py
@@ -49,6 +49,7 @@ def one_step_corrected_estimator(
                 [a + b for a, b in zip(flat_plug_in_estimate, flat_correction)],
                 treespec,
             )
+
         return _estimator
 
     return _corrected_functional

--- a/chirho/robust/handlers/estimators.py
+++ b/chirho/robust/handlers/estimators.py
@@ -83,7 +83,7 @@ def one_step_corrected_estimator(
         [Callable[P, Any], Callable[P, Any], Optional[Functional[P, S]]],
         Callable[Concatenate[Point[T], P], S],
     ]
-    :return: function to computer the one-step corrected estimator
+    :return: function to compute the one-step corrected estimator
     :rtype: S
     """
     if functional is None:

--- a/chirho/robust/handlers/estimators.py
+++ b/chirho/robust/handlers/estimators.py
@@ -9,6 +9,10 @@ def one_step_correction(
     model: Callable[P, Any],
     guide: Callable[P, Any],
     functional: Optional[Functional[P, S]] = None,
+    influence_fn_estimator: Callable[
+        [Callable[P, Any], Callable[P, Any], Optional[Functional[P, S]]],
+        Callable[Concatenate[Point[T], P], S],
+    ] = influence_fn,
     **influence_kwargs,
 ) -> Callable[Concatenate[Point[T], P], S]:
     """
@@ -23,6 +27,12 @@ def one_step_correction(
     :param functional: model summary of interest, which is a function of the
         model and guide. If ``None``, defaults to :class:`PredictiveFunctional`.
     :type functional: Optional[Functional[P, S]], optional
+    :param influence_fn_estimator: function to approximate the efficient influence
+        function. Defaults to :func:`influence_fn`.
+    :type influence_fn_estimator: Callable[
+        [Callable[P, Any], Callable[P, Any], Optional[Functional[P, S]]],
+        Callable[Concatenate[Point[T], P], S],
+    ]
     :return: function to compute the one-step correction
     :rtype: Callable[Concatenate[Point[T], P], S]
 
@@ -33,9 +43,51 @@ def one_step_correction(
     """
     influence_kwargs_one_step = influence_kwargs.copy()
     influence_kwargs_one_step["pointwise_influence"] = False
-    eif_fn = influence_fn(model, guide, functional, **influence_kwargs_one_step)
+    eif_fn = influence_fn_estimator(
+        model, guide, functional, **influence_kwargs_one_step
+    )
 
     def _one_step(test_data: Point[T], *args, **kwargs) -> S:
         return eif_fn(test_data, *args, **kwargs)
 
     return _one_step
+
+
+def one_step_corrected_estimator(
+    test_data: Point[T],
+    model: Callable[P, Any],
+    guide: Callable[P, Any],
+    functional: Optional[Functional[P, S]] = None,
+    influence_fn_estimator=influence_fn,
+    **influence_kwargs,
+) -> S:
+    """
+    Returns the one-step corrected estimator for the functional at a
+    specified set of test points as discussed in [1].
+
+    :param test_data: test data
+    :type test_data: Point[T]
+    :param model: Python callable containing Pyro primitives.
+    :type model: Callable[P, Any]
+    :param guide: Python callable containing Pyro primitives.
+        Must only contain continuous latent variables.
+    :type guide: Callable[P, Any]
+    :param functional: model summary of interest, which is a function of the
+        model and guide. If ``None``, defaults to :class:`PredictiveFunctional`.
+    :type functional: Optional[Functional[P, S]], optional
+    :param influence_fn_estimator: function to approximate the efficient influence
+        function. Defaults to :func:`influence_fn`.
+    :type influence_fn_estimator: Callable[
+        [Callable[P, Any], Callable[P, Any], Optional[Functional[P, S]]],
+        Callable[Concatenate[Point[T], P], S],
+    ]
+    :return: the one-step corrected estimator for the functional evaluated at the
+        test points.
+    :rtype: S
+    """
+    plug_in_estimate = functional(model, guide)()
+    correction = one_step_correction(
+        model, guide, functional, influence_fn_estimator, **influence_kwargs
+    )(test_data)
+    
+    return plug_in_estimate + correction

--- a/chirho/robust/handlers/estimators.py
+++ b/chirho/robust/handlers/estimators.py
@@ -36,7 +36,7 @@ def one_step_corrected_estimator(
         plug_in_estimator = functional(model)
         correction_estimator = eif_fn(model)
 
-        def _estimate_model(*args, **kwargs) -> S:
+        def _estimator(*args, **kwargs) -> S:
             plug_in_estimate = plug_in_estimator(*args, **kwargs)
             correction = correction_estimator(*args, **kwargs)
 
@@ -49,6 +49,6 @@ def one_step_corrected_estimator(
                 [a + b for a, b in zip(flat_plug_in_estimate, flat_correction)],
                 treespec,
             )
-        return _estimate_model
+        return _estimator
 
     return _corrected_functional

--- a/chirho/robust/handlers/estimators.py
+++ b/chirho/robust/handlers/estimators.py
@@ -34,9 +34,7 @@ def one_step_correction(
     """
     influence_kwargs_one_step = influence_kwargs.copy()
     influence_kwargs_one_step["pointwise_influence"] = False
-    eif_fn = influence_fn(
-        model, guide, functional, **influence_kwargs_one_step
-    )
+    eif_fn = influence_fn(model, guide, functional, **influence_kwargs_one_step)
 
     def _one_step(test_data: Point[T], *args, **kwargs) -> S:
         return eif_fn(test_data, *args, **kwargs)
@@ -60,14 +58,8 @@ def one_step_corrected_estimator(
         Must only contain continuous latent variables.
     :type guide: Callable[P, Any]
     :param functional: model summary of interest, which is a function of the
-        model and guide. If ``None``, defaults to :class:`PredictiveFunctional`.
+        model and guide.
     :type functional: Functional[P, S]
-    :param influence_fn_estimator: function to approximate the efficient influence
-        function. Defaults to :func:`influence_fn`.
-    :type influence_fn_estimator: Callable[
-        [Callable[P, Any], Callable[P, Any], Optional[Functional[P, S]]],
-        Callable[Concatenate[Point[T], P], S],
-    ]
     :return: function to compute the one-step corrected estimator
     :rtype: S
     """

--- a/chirho/robust/handlers/estimators.py
+++ b/chirho/robust/handlers/estimators.py
@@ -107,7 +107,9 @@ def one_step_corrected_estimator(
 
 @singledispatch
 def apply_correction(plug_in_estimate, correction: S) -> S:
-    raise NotImplementedError
+    raise NotImplementedError(
+        "The functional must produce a function that return a torch Tensor or a dict of torch Tensors"
+    )
 
 
 @apply_correction.register(dict)

--- a/chirho/robust/handlers/estimators.py
+++ b/chirho/robust/handlers/estimators.py
@@ -32,9 +32,9 @@ def one_step_corrected_estimator(
     influence_kwargs_one_step["pointwise_influence"] = False
     eif_fn = influence_fn(functional, *test_points, **influence_kwargs_one_step)
 
-    def _corrected_functional(model: Callable[P, Any]) -> Callable[P, S]:
-        plug_in_estimator = functional(model)
-        correction_estimator = eif_fn(model)
+    def _corrected_functional(*model: Callable[P, Any]) -> Callable[P, S]:
+        plug_in_estimator = functional(*model)
+        correction_estimator = eif_fn(*model)
 
         def _estimator(*args, **kwargs) -> S:
             plug_in_estimate = plug_in_estimator(*args, **kwargs)

--- a/tests/robust/test_handlers.py
+++ b/tests/robust/test_handlers.py
@@ -90,4 +90,4 @@ def test_estimator_smoke(
         assert not torch.isinf(v).any(), f"one_step for {k} had infs"
         assert not torch.isclose(
             v, torch.zeros_like(v)
-        ).all(), f"one_step for {k} was zero"
+        ).all(), f"{estimation_method} estimator for {k} was zero"

--- a/tests/robust/test_handlers.py
+++ b/tests/robust/test_handlers.py
@@ -75,11 +75,11 @@ def test_estimator_smoke(
         cg_iters=cg_iters,
     )(PredictiveModel(model, guide))
 
-    one_step_on_test: Mapping[str, torch.Tensor] = estimator()
-    assert len(one_step_on_test) > 0
-    for k, v in one_step_on_test.items():
-        assert not torch.isnan(v).any(), f"one_step for {k} had nans"
-        assert not torch.isinf(v).any(), f"one_step for {k} had infs"
+    estimate_on_test: Mapping[str, torch.Tensor] = estimator()
+    assert len(estimate_on_test) > 0
+    for k, v in estimate_on_test.items():
+        assert not torch.isnan(v).any(), f"{estimation_method} for {k} had nans"
+        assert not torch.isinf(v).any(), f"{estimation_method} for {k} had infs"
         assert not torch.isclose(
             v, torch.zeros_like(v)
         ).all(), f"{estimation_method} estimator for {k} was zero"


### PR DESCRIPTION
This small refactoring PR introduces a a new estimator that applies the the one-step correction to the plug-in estimator. This new estimator, `one_step_corrected_estimator`, avoids confusion about how the correction should be applied.

In addition, this PR slightly refactors the existing handler smoke tests to be parametric in the estimation method.