### PR TITLE
Add explainable module to Sphinx build

### DIFF
--- a/docs/source/explainable.rst
+++ b/docs/source/explainable.rst
@@ -1,0 +1,47 @@
+Explainable
+===========
+
+.. automodule:: chirho.explainable
+   :members:
+   :undoc-members:
+
+Operations
+----------
+
+.. automodule:: chirho.explainable.ops
+   :members:
+   :undoc-members:
+
+Handlers
+--------
+
+.. automodule:: chirho.explainable.handlers
+   :members:
+   :undoc-members:
+
+.. automodule:: chirho.explainable.handlers.alternatives
+   :members:
+   :undoc-members:
+
+.. automodule:: chirho.explainable.handlers.explanation
+   :members:
+   :undoc-members:
+
+.. automodule:: chirho.explainable.handlers.preemptions
+   :members:
+   :undoc-members:
+
+.. automodule:: chirho.explainable.handlers.split_subsets
+   :members:
+   :undoc-members:
+
+Internals
+---------
+
+.. automodule:: chirho.explainable.internals
+   :members:
+   :undoc-members:
+
+.. automodule:: chirho.explainable.internals.defaults
+   :members:
+   :undoc-members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,6 +41,7 @@ Table of Contents
    observational
    indexed
    dynamical
+   explainable
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
This PR adds the necessary stub files to make the documentation for `chirho.explainable` appear in our Sphinx builds.