### PR TITLE
Make functional argument to influence_fn required

### DIFF
--- a/chirho/robust/handlers/estimators.py
+++ b/chirho/robust/handlers/estimators.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from typing_extensions import Concatenate
 
@@ -8,7 +8,7 @@ from chirho.robust.ops import Functional, P, Point, S, T, influence_fn
 def one_step_correction(
     model: Callable[P, Any],
     guide: Callable[P, Any],
-    functional: Optional[Functional[P, S]] = None,
+    functional: Functional[P, S],
     **influence_kwargs,
 ) -> Callable[Concatenate[Point[T], P], S]:
     """
@@ -21,8 +21,8 @@ def one_step_correction(
     :param guide: Python callable containing Pyro primitives.
     :type guide: Callable[P, Any]
     :param functional: model summary of interest, which is a function of the
-        model and guide. If ``None``, defaults to :class:`PredictiveFunctional`.
-    :type functional: Optional[Functional[P, S]], optional
+        model and guide.
+    :type functional: Functional[P, S]
     :return: function to compute the one-step correction
     :rtype: Callable[Concatenate[Point[T], P], S]
 

--- a/chirho/robust/ops.py
+++ b/chirho/robust/ops.py
@@ -18,7 +18,7 @@ Functional = Callable[[Callable[P, Any], Callable[P, Any]], Callable[P, S]]
 def influence_fn(
     model: Callable[P, Any],
     guide: Callable[P, Any],
-    functional: Optional[Functional[P, S]] = None,
+    functional: Functional[P, S],
     **linearize_kwargs
 ) -> Callable[Concatenate[Point[T], P], S]:
     """
@@ -116,17 +116,10 @@ def influence_fn(
           https://github.com/BasisResearch/chirho/issues/393.
     """
     from chirho.robust.internals.linearize import linearize
-    from chirho.robust.internals.predictive import PredictiveFunctional
     from chirho.robust.internals.utils import make_functional_call
 
     linearized = linearize(model, guide, **linearize_kwargs)
-
-    if functional is None:
-        assert isinstance(model, torch.nn.Module)
-        assert isinstance(guide, torch.nn.Module)
-        target = PredictiveFunctional(model, guide)
-    else:
-        target = functional(model, guide)
+    target = functional(model, guide)
 
     # TODO check that target_params == model_params | guide_params
     assert isinstance(target, torch.nn.Module)

--- a/chirho/robust/ops.py
+++ b/chirho/robust/ops.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Any, Callable, Mapping, Optional, TypeVar
+from typing import Any, Callable, Mapping, TypeVar
 
 import torch
 from typing_extensions import Concatenate, ParamSpec

--- a/chirho/robust/ops.py
+++ b/chirho/robust/ops.py
@@ -32,8 +32,8 @@ def influence_fn(
         Must only contain continuous latent variables.
     :type guide: Callable[P, Any]
     :param functional: model summary of interest, which is a function of the
-        model and guide. If ``None``, defaults to :class:`PredictiveFunctional`.
-    :type functional: Optional[Functional[P, S]], optional
+        model and guide.
+    :type functional: Functional[P, S]
     :return: the efficient influence function for ``functional``
     :rtype: Callable[Concatenate[Point[T], P], S]
 

--- a/tests/robust/test_ops.py
+++ b/tests/robust/test_ops.py
@@ -59,9 +59,7 @@ def test_nmc_predictive_influence_smoke(
     predictive_eif = influence_fn(
         model,
         guide,
-        functional=functools.partial(
-            PredictiveFunctional, num_samples=num_predictive_samples
-        ),
+        functools.partial(PredictiveFunctional, num_samples=num_predictive_samples),
         max_plate_nesting=max_plate_nesting,
         num_samples_outer=num_samples_outer,
         num_samples_inner=num_samples_inner,
@@ -106,9 +104,7 @@ def test_nmc_predictive_influence_vmap_smoke(
     predictive_eif = influence_fn(
         model,
         guide,
-        functional=functools.partial(
-            PredictiveFunctional, num_samples=num_predictive_samples
-        ),
+        functools.partial(PredictiveFunctional, num_samples=num_predictive_samples),
         max_plate_nesting=max_plate_nesting,
         num_samples_outer=num_samples_outer,
         num_samples_inner=num_samples_inner,


### PR DESCRIPTION
This refactoring PR removes the default behavior for the `functional` argument of `influence_fn`, and makes a value for this argument mandatory.