### PR TITLE
Make influence_fn a higher-order Functional

### DIFF
--- a/chirho/robust/handlers/estimators.py
+++ b/chirho/robust/handlers/estimators.py
@@ -1,6 +1,6 @@
-from typing import Any, Callable, TypeVar
+from typing import TypeVar
 
-from typing_extensions import Concatenate, ParamSpec
+from typing_extensions import ParamSpec
 
 from chirho.robust.ops import Functional, Point, influence_fn
 
@@ -10,21 +10,17 @@ T = TypeVar("T")
 
 
 def one_step_correction(
-    model: Callable[P, Any],
     functional: Functional[P, S],
+    test_data: Point[T],
     **influence_kwargs,
-) -> Callable[Concatenate[Point[T], P], S]:
+) -> Functional[P, S]:
     """
     Returns a function that computes the one-step correction for the
     functional at a specified set of test points as discussed in
     [1].
 
-    :param model: Python callable containing Pyro primitives.
-    :type model: Callable[P, Any]
     :param functional: model summary of interest, which is a function of the model.
-    :type functional: Functional[P, S]
-    :return: function to compute the one-step correction
-    :rtype: Callable[Concatenate[Point[T], P], S]
+    :return: functional to compute the one-step correction
 
     **References**
 
@@ -33,9 +29,4 @@ def one_step_correction(
     """
     influence_kwargs_one_step = influence_kwargs.copy()
     influence_kwargs_one_step["pointwise_influence"] = False
-    eif_fn = influence_fn(model, functional, **influence_kwargs_one_step)
-
-    def _one_step(test_data: Point[T], *args, **kwargs) -> S:
-        return eif_fn(test_data, *args, **kwargs)
-
-    return _one_step
+    return influence_fn(functional, test_data, **influence_kwargs_one_step)

--- a/chirho/robust/handlers/estimators.py
+++ b/chirho/robust/handlers/estimators.py
@@ -11,15 +11,15 @@ T = TypeVar("T")
 
 def one_step_correction(
     functional: Functional[P, S],
-    test_data: Point[T],
+    *test_points: Point[T],
     **influence_kwargs,
 ) -> Functional[P, S]:
     """
-    Returns a function that computes the one-step correction for the
-    functional at a specified set of test points as discussed in
-    [1].
+    Returns a functional that computes the one-step correction for the
+    functional at a specified set of test points as discussed in [1].
 
-    :param functional: model summary of interest, which is a function of the model.
+    :param functional: model summary functional of interest
+    :param test_points: points at which to compute the one-step correction
     :return: functional to compute the one-step correction
 
     **References**
@@ -29,4 +29,4 @@ def one_step_correction(
     """
     influence_kwargs_one_step = influence_kwargs.copy()
     influence_kwargs_one_step["pointwise_influence"] = False
-    return influence_fn(functional, test_data, **influence_kwargs_one_step)
+    return influence_fn(functional, *test_points, **influence_kwargs_one_step)

--- a/chirho/robust/internals/linearize.py
+++ b/chirho/robust/internals/linearize.py
@@ -328,7 +328,7 @@ def linearize(
           https://github.com/BasisResearch/chirho/issues/393.
     """
     if len(models) > 1:
-        raise NotImplementedError("Batched linearization not yet implemented")
+        raise NotImplementedError("Only unary version of linearize is implemented.")
     else:
         (model,) = models
 

--- a/chirho/robust/internals/linearize.py
+++ b/chirho/robust/internals/linearize.py
@@ -219,8 +219,7 @@ def make_empirical_fisher_vp(
 
 
 def linearize(
-    model: Callable[P, Any],
-    *,
+    *models: Callable[P, Any],
     num_samples_outer: int,
     num_samples_inner: Optional[int] = None,
     max_plate_nesting: Optional[int] = None,
@@ -328,6 +327,11 @@ def linearize(
           This issue will be addressed in a future release:
           https://github.com/BasisResearch/chirho/issues/393.
     """
+    if len(models) > 1:
+        raise NotImplementedError("Batched linearization not yet implemented")
+    else:
+        (model,) = models
+
     assert isinstance(model, torch.nn.Module)
     if num_samples_inner is None:
         num_samples_inner = num_samples_outer**2

--- a/chirho/robust/ops.py
+++ b/chirho/robust/ops.py
@@ -122,7 +122,7 @@ def influence_fn(
         """
         Functional representing the efficient influence function of ``functional`` at ``points`` .
 
-        :param model: Python callable containing Pyro primitives.
+        :param models: Python callables containing Pyro primitives.
         :return: efficient influence function for ``functional`` evaluated at ``model`` and ``points``
         """
         if len(models) != len(points):

--- a/chirho/robust/ops.py
+++ b/chirho/robust/ops.py
@@ -14,7 +14,9 @@ Point = Mapping[str, Observation[T]]
 
 
 class Functional(Protocol[P, S]):
-    def __call__(self, *models: Callable[P, Any]) -> Callable[P, S]:
+    def __call__(
+        self, __model: Callable[P, Any], *models: Callable[P, Any]
+    ) -> Callable[P, S]:
         ...
 
 
@@ -22,15 +24,12 @@ def influence_fn(
     functional: Functional[P, S], *points: Point[T], **linearize_kwargs
 ) -> Functional[P, S]:
     """
-    Returns the efficient influence function for ``functional``
-    with respect to the parameters of probabilistic program ``model``.
+    Returns a new functional that computes the efficient influence function for ``functional``
+    at the given ``points`` with respect to the parameters of its probabilistic program arguments.
 
     :param functional: model summary of interest, which is a function of ``model``
-    :type functional: Functional[P, S]
-    :param points: points at which to compute the efficient influence function
-    :type points: Point[T]
-    :return: the efficient influence function for ``functional``
-    :rtype: Callable[Concatenate[Point[T], P], S]
+    :param points: points for each input to ``functional`` at which to compute the efficient influence function
+    :return: functional that computes the efficient influence function for ``functional`` at ``points``
 
     **Example usage**:
 
@@ -141,7 +140,6 @@ def influence_fn(
             point in ``points``.
 
             :return: efficient influence function evaluated at each point in ``points`` or averaged
-            :rtype: S
             """
             param_eif = linearized(*points, *args, **kwargs)
             return torch.vmap(

--- a/tests/robust/test_handlers.py
+++ b/tests/robust/test_handlers.py
@@ -56,15 +56,6 @@ def test_one_step_correction_smoke(
     guide = guide(model)
     model(), guide()  # initialize
 
-    one_step = one_step_correction(
-        PredictiveModel(model, guide),
-        functools.partial(PredictiveFunctional, num_samples=num_predictive_samples),
-        max_plate_nesting=max_plate_nesting,
-        num_samples_outer=num_samples_outer,
-        num_samples_inner=num_samples_inner,
-        cg_iters=cg_iters,
-    )
-
     with torch.no_grad():
         test_datum = {
             k: v[0]
@@ -72,6 +63,15 @@ def test_one_step_correction_smoke(
                 model, num_samples=2, return_sites=obs_names, parallel=True
             )().items()
         }
+
+    one_step = one_step_correction(
+        functools.partial(PredictiveFunctional, num_samples=num_predictive_samples),
+        test_datum,
+        max_plate_nesting=max_plate_nesting,
+        num_samples_outer=num_samples_outer,
+        num_samples_inner=num_samples_inner,
+        cg_iters=cg_iters,
+    )(PredictiveModel(model, guide))
 
     one_step_on_test: Mapping[str, torch.Tensor] = one_step(test_datum)
     assert len(one_step_on_test) > 0

--- a/tests/robust/test_handlers.py
+++ b/tests/robust/test_handlers.py
@@ -73,7 +73,7 @@ def test_one_step_correction_smoke(
         cg_iters=cg_iters,
     )(PredictiveModel(model, guide))
 
-    one_step_on_test: Mapping[str, torch.Tensor] = one_step(test_datum)
+    one_step_on_test: Mapping[str, torch.Tensor] = one_step()
     assert len(one_step_on_test) > 0
     for k, v in one_step_on_test.items():
         assert not torch.isnan(v).any(), f"one_step for {k} had nans"

--- a/tests/robust/test_ops.py
+++ b/tests/robust/test_ops.py
@@ -56,15 +56,6 @@ def test_nmc_predictive_influence_smoke(
     guide = guide(model)
     model(), guide()  # initialize
 
-    predictive_eif = influence_fn(
-        PredictiveModel(model, guide),
-        functools.partial(PredictiveFunctional, num_samples=num_predictive_samples),
-        max_plate_nesting=max_plate_nesting,
-        num_samples_outer=num_samples_outer,
-        num_samples_inner=num_samples_inner,
-        cg_iters=cg_iters,
-    )
-
     with torch.no_grad():
         test_datum = {
             k: v[0]
@@ -73,7 +64,16 @@ def test_nmc_predictive_influence_smoke(
             )().items()
         }
 
-    test_datum_eif: Mapping[str, torch.Tensor] = predictive_eif(test_datum)
+    predictive_eif = influence_fn(
+        functools.partial(PredictiveFunctional, num_samples=num_predictive_samples),
+        test_datum,
+        max_plate_nesting=max_plate_nesting,
+        num_samples_outer=num_samples_outer,
+        num_samples_inner=num_samples_inner,
+        cg_iters=cg_iters,
+    )(PredictiveModel(model, guide))
+
+    test_datum_eif: Mapping[str, torch.Tensor] = predictive_eif()
     assert len(test_datum_eif) > 0
     for k, v in test_datum_eif.items():
         assert not torch.isnan(v).any(), f"eif for {k} had nans"
@@ -100,21 +100,21 @@ def test_nmc_predictive_influence_vmap_smoke(
 
     model(), guide()  # initialize
 
-    predictive_eif = influence_fn(
-        PredictiveModel(model, guide),
-        functools.partial(PredictiveFunctional, num_samples=num_predictive_samples),
-        max_plate_nesting=max_plate_nesting,
-        num_samples_outer=num_samples_outer,
-        num_samples_inner=num_samples_inner,
-        cg_iters=cg_iters,
-    )
-
     with torch.no_grad():
         test_data = pyro.infer.Predictive(
             model, num_samples=4, return_sites=obs_names, parallel=True
         )()
 
-    test_data_eif: Mapping[str, torch.Tensor] = predictive_eif(test_data)
+    predictive_eif = influence_fn(
+        functools.partial(PredictiveFunctional, num_samples=num_predictive_samples),
+        test_data,
+        max_plate_nesting=max_plate_nesting,
+        num_samples_outer=num_samples_outer,
+        num_samples_inner=num_samples_inner,
+        cg_iters=cg_iters,
+    )(PredictiveModel(model, guide))
+
+    test_data_eif: Mapping[str, torch.Tensor] = predictive_eif()
     assert len(test_data_eif) > 0
     for k, v in test_data_eif.items():
         assert not torch.isnan(v).any(), f"eif for {k} had nans"


### PR DESCRIPTION
Addresses #479, #480 

This PR changes the type signature of `chirho.robust.ops.influence_fn` to make it more compositional, following the suggestions in #479 and #480. In particular, `influence_fn` is now a higher-order functional that maps a target functional to another functional:
```py
def influence_fn(functional: Functional[P, S], *points: Point[T]) -> Functional[P, S]: ...
```
It also generalizes the `Functional` interface (and therefore those of `influence_fn` and `linearize`) to arbitrary arities (but still only implements the unary case):
```py
class Functional(Protocol[P, S]):
    def __call__(self, __model: Callable[P, Any], *models: Callable[P, Any]) -> Callable[P, S]: ...
```
Bundling these interface changes together in one PR will hopefully ensure that there will only be one set of merge conflicts associated with #479 and #480 to resolve in other open PRs targeting `staging-robust`.