### PR TITLE
Fix memory leak issue in `linearize`

### DIFF
--- a/chirho/robust/ops.py
+++ b/chirho/robust/ops.py
@@ -16,8 +16,7 @@ Point = Mapping[str, Observation[T]]
 class Functional(Protocol[P, S]):
     def __call__(
         self, __model: Callable[P, Any], *models: Callable[P, Any]
-    ) -> Callable[P, S]:
-        ...
+    ) -> Callable[P, S]: ...
 
 
 def influence_fn(
@@ -127,7 +126,7 @@ def influence_fn(
         if len(models) != len(points):
             raise ValueError("mismatch between number of models and points")
 
-        linearized = linearize(*models, **linearize_kwargs)
+        linearized = linearize(*models, **linearize_kwargs)  # type: ignore
         target = functional(*models)
 
         # TODO check that target_params == model_params

--- a/tests/robust/robust_fixtures.py
+++ b/tests/robust/robust_fixtures.py
@@ -228,3 +228,17 @@ def closed_form_ate_correction(
     analytic_eif_at_test_pts = (A / pi_X - (1 - A) / (1 - pi_X)) * (Y - mu_X)
     analytic_correction = analytic_eif_at_test_pts.mean()
     return analytic_correction, analytic_eif_at_test_pts
+
+
+def humansize(nbytes):
+    # Taken from:
+    # https://stackoverflow.com/questions/61462876/macos-activity-monitor-commands-cached-files-in-python
+    """Appends prefix to bytes for human readability."""
+
+    suffixes = ["B", "KB", "MB", "GB", "TB", "PB"]
+    i = 0
+    while nbytes >= 1024 and i < len(suffixes) - 1:
+        nbytes /= 1024.0
+        i += 1
+    f = ("%.2f" % nbytes).rstrip("0").rstrip(".")
+    return "%s %s" % (f, suffixes[i])

--- a/tests/robust/robust_fixtures.py
+++ b/tests/robust/robust_fixtures.py
@@ -187,6 +187,29 @@ class BenchmarkLinearModel(HighDimLinearModel):
         return torch.zeros(self.p), torch.ones(self.p)
 
 
+class ToyNormal(pyro.nn.PyroModule):
+    def forward(self):
+        mu = pyro.sample("mu", dist.Normal(0.0, 1.0))
+        sd = pyro.sample("sd", dist.HalfNormal(1.0))
+        return pyro.sample(
+            "Y",
+            dist.Normal(mu, scale=sd),
+        )
+
+
+class GroundTruthToyNormal(pyro.nn.PyroModule):
+    def __init__(self, mu_true, sd_true):
+        super().__init__()
+        self.mu_true = mu_true
+        self.sd_true = sd_true
+
+    def forward(self):
+        return pyro.sample(
+            "Y",
+            dist.Normal(self.mu_true, scale=self.sd_true),
+        )
+
+
 class MLEGuide(torch.nn.Module):
     def __init__(self, mle_est: ParamDict):
         super().__init__()
@@ -232,7 +255,7 @@ def closed_form_ate_correction(
 
 def humansize(nbytes):
     # Taken from:
-    # https://stackoverflow.com/questions/61462876/macos-activity-monitor-commands-cached-files-in-python
+    # https://stackoverflow.com/questions/61462876/
     """Appends prefix to bytes for human readability."""
 
     suffixes = ["B", "KB", "MB", "GB", "TB", "PB"]

--- a/tests/robust/test_internals_linearize.py
+++ b/tests/robust/test_internals_linearize.py
@@ -261,7 +261,7 @@ def test_fisher_grad_smoke(data_config):
     N_monte_carlo = 10000
     data = Predictive(GaussianModel(cov_mat), num_samples=N_monte_carlo)(loc)
     empirical_fisher_vp_func = make_empirical_fisher_vp(
-        func_log_prob, log_prob_params, data, cov_mat=cov_mat
+        func_log_prob, log_prob_params, data, detach=False, cov_mat=cov_mat
     )
 
     v = 0.5 * torch.ones(cov_mat.shape[1], requires_grad=True)

--- a/tests/robust/test_memory_leak.py
+++ b/tests/robust/test_memory_leak.py
@@ -2,13 +2,11 @@ import math
 
 import psutil
 import pyro
-import pyro.distributions as dist
 import torch
 from pyro.infer import Predictive
 
 from chirho.robust.handlers.predictive import PredictiveModel
 from chirho.robust.internals.linearize import linearize
-from chirho.robust.internals.utils import ParamDict
 
 from .robust_fixtures import GroundTruthToyNormal, MLEGuide, ToyNormal, humansize
 

--- a/tests/robust/test_memory_leak.py
+++ b/tests/robust/test_memory_leak.py
@@ -124,27 +124,27 @@ def test_linearize_does_not_leak_memory_no_grad():
     Y_pts = torch.sort(Y_pts).values
 
     free_memory = []
-    with torch.no_grad():
-        for i in range(25):
-            mem = psutil.virtual_memory()
+    for i in range(25):
+        mem = psutil.virtual_memory()
 
-            theta_true = {
-                "mu": torch.tensor(mu_true, requires_grad=True),
-                "sd": torch.tensor(sd_true, requires_grad=True),
-            }
-            model = ToyNormal()
-            guide = MLEGuide(theta_true)
+        theta_true = {
+            "mu": torch.tensor(mu_true, requires_grad=True),
+            "sd": torch.tensor(sd_true, requires_grad=True),
+        }
+        model = ToyNormal()
+        guide = MLEGuide(theta_true)
 
-            # Linearize model
+        # Linearize model
+        with torch.no_grad():
             monte_eif = linearize(
                 PredictiveModel(model, guide),
                 num_samples_outer=10000,
                 num_samples_inner=1,
                 detach=False,
             )({"Y": Y_pts})
-            free_memory.append(mem.free)
-            memory_size = humansize(mem.free)
-            print(f"Iteration: {i}, Detached: {True}, Free Memory: {memory_size}")
+        free_memory.append(mem.free)
+        memory_size = humansize(mem.free)
+        print(f"Iteration: {i}, Detached: {True}, Free Memory: {memory_size}")
 
     # Free memory should not be more than 10x different than the initial free memory
     assert math.fabs((free_memory[-1] - free_memory[1])) / free_memory[1] < 0.1

--- a/tests/robust/test_memory_leak.py
+++ b/tests/robust/test_memory_leak.py
@@ -10,32 +10,9 @@ from chirho.robust.handlers.predictive import PredictiveModel
 from chirho.robust.internals.linearize import linearize
 from chirho.robust.internals.utils import ParamDict
 
-from .robust_fixtures import MLEGuide, humansize
+from .robust_fixtures import GroundTruthToyNormal, MLEGuide, ToyNormal, humansize
 
 pyro.settings.set(module_local_params=True)
-
-
-class ToyNormal(pyro.nn.PyroModule):
-    def forward(self):
-        mu = pyro.sample("mu", dist.Normal(0.0, 1.0))
-        sd = pyro.sample("sd", dist.HalfNormal(1.0))
-        return pyro.sample(
-            "Y",
-            dist.Normal(mu, scale=sd),
-        )
-
-
-class GroundTruthToyNormal(pyro.nn.PyroModule):
-    def __init__(self, mu_true, sd_true):
-        super().__init__()
-        self.mu_true = mu_true
-        self.sd_true = sd_true
-
-    def forward(self):
-        return pyro.sample(
-            "Y",
-            dist.Normal(self.mu_true, scale=self.sd_true),
-        )
 
 
 def test_linearize_does_not_leak_memory_new_interface():

--- a/tests/robust/test_memory_leak.py
+++ b/tests/robust/test_memory_leak.py
@@ -44,8 +44,8 @@ def test_linearize_does_not_leak_memory_new_interface():
         memory_size = humansize(mem.free)
         print(f"Iteration: {i}, Detached: {True}, Free Memory: {memory_size}")
 
-    # Free memory should not be more than 10x different than the initial free memory
-    assert math.fabs((free_memory[-1] - free_memory[1])) / free_memory[1] < 0.1
+    # Free memory should not be too different than the initial free memory
+    assert math.fabs((free_memory[-1] - free_memory[1])) / free_memory[1] < 0.3
 
 
 def test_linearize_does_not_leak_memory_no_grad():
@@ -80,5 +80,5 @@ def test_linearize_does_not_leak_memory_no_grad():
         memory_size = humansize(mem.free)
         print(f"Iteration: {i}, Detached: {True}, Free Memory: {memory_size}")
 
-    # Free memory should not be more than 10x different than the initial free memory
-    assert math.fabs((free_memory[-1] - free_memory[1])) / free_memory[1] < 0.1
+    # Free memory should not be too different than the initial free memory
+    assert math.fabs((free_memory[-1] - free_memory[1])) / free_memory[1] < 0.3

--- a/tests/robust/test_memory_leak.py
+++ b/tests/robust/test_memory_leak.py
@@ -1,3 +1,5 @@
+import math
+
 import psutil
 import pyro
 import pyro.distributions as dist
@@ -77,15 +79,16 @@ def humansize(nbytes):
     return "%s %s" % (f, suffixes[i])
 
 
-N_pts = 500
-mu_true = 0.0
-sd_true = 1.0
-true_model = GroundTruthToyNormal(mu_true, sd_true)
-D_pts = Predictive(true_model, num_samples=N_pts, return_sites=["Y"])()
-Y_pts = D_pts["Y"]
-Y_pts = torch.sort(Y_pts).values
+def test_linearize_does_not_leak_memory_new_interface():
+    N_pts = 500
+    mu_true = 0.0
+    sd_true = 1.0
+    true_model = GroundTruthToyNormal(mu_true, sd_true)
+    D_pts = Predictive(true_model, num_samples=N_pts, return_sites=["Y"])()
+    Y_pts = D_pts["Y"]
+    Y_pts = torch.sort(Y_pts).values
 
-for detach in [True, False]:
+    free_memory = []
     for i in range(25):
         mem = psutil.virtual_memory()
 
@@ -101,8 +104,47 @@ for detach in [True, False]:
             PredictiveModel(model, guide),
             num_samples_outer=10000,
             num_samples_inner=1,
-            detach=detach,
+            detach=True,
         )({"Y": Y_pts})
+        free_memory.append(mem.free)
         memory_size = humansize(mem.free)
-        print(f"Iteration: {i}, Detached: {detach}, Free Memory: {memory_size}")
-    print("\n")
+        print(f"Iteration: {i}, Detached: {True}, Free Memory: {memory_size}")
+
+    # Free memory should not be more than 10x different than the initial free memory
+    assert math.fabs((free_memory[-1] - free_memory[1])) / free_memory[1] < 0.1
+
+
+def test_linearize_does_not_leak_memory_no_grad():
+    N_pts = 500
+    mu_true = 0.0
+    sd_true = 1.0
+    true_model = GroundTruthToyNormal(mu_true, sd_true)
+    D_pts = Predictive(true_model, num_samples=N_pts, return_sites=["Y"])()
+    Y_pts = D_pts["Y"]
+    Y_pts = torch.sort(Y_pts).values
+
+    free_memory = []
+    with torch.no_grad():
+        for i in range(25):
+            mem = psutil.virtual_memory()
+
+            theta_true = {
+                "mu": torch.tensor(mu_true, requires_grad=True),
+                "sd": torch.tensor(sd_true, requires_grad=True),
+            }
+            model = ToyNormal()
+            guide = MLEGuide(theta_true)
+
+            # Linearize model
+            monte_eif = linearize(
+                PredictiveModel(model, guide),
+                num_samples_outer=10000,
+                num_samples_inner=1,
+                detach=False,
+            )({"Y": Y_pts})
+            free_memory.append(mem.free)
+            memory_size = humansize(mem.free)
+            print(f"Iteration: {i}, Detached: {True}, Free Memory: {memory_size}")
+
+    # Free memory should not be more than 10x different than the initial free memory
+    assert math.fabs((free_memory[-1] - free_memory[1])) / free_memory[1] < 0.1

--- a/tests/robust/test_memory_leak.py
+++ b/tests/robust/test_memory_leak.py
@@ -1,0 +1,108 @@
+import psutil
+import pyro
+import pyro.distributions as dist
+import torch
+from pyro.infer import Predictive
+
+from chirho.robust.handlers.predictive import PredictiveModel
+from chirho.robust.internals.linearize import linearize
+from chirho.robust.internals.utils import ParamDict
+
+pyro.settings.set(module_local_params=True)
+
+
+class ToyNormal(pyro.nn.PyroModule):
+    def forward(self):
+        mu = pyro.sample("mu", dist.Normal(0.0, 1.0))
+        sd = pyro.sample("sd", dist.HalfNormal(1.0))
+        return pyro.sample(
+            "Y",
+            dist.Normal(mu, scale=sd),
+        )
+
+
+class ToyNormalKnownSD(pyro.nn.PyroModule):
+    def __init__(self, sd_true):
+        super().__init__()
+        self.sd_true = sd_true
+
+    def forward(self):
+        mu = pyro.sample("mu", dist.Normal(0.0, 1.0))
+        sd = pyro.sample("sd", dist.HalfNormal(1.0))
+        return pyro.sample(
+            "Y",
+            dist.Normal(mu, scale=self.sd_true),
+        )
+
+
+class GroundTruthToyNormal(pyro.nn.PyroModule):
+    def __init__(self, mu_true, sd_true):
+        super().__init__()
+        self.mu_true = mu_true
+        self.sd_true = sd_true
+
+    def forward(self):
+        return pyro.sample(
+            "Y",
+            dist.Normal(self.mu_true, scale=self.sd_true),
+        )
+
+
+class MLEGuide(torch.nn.Module):
+    def __init__(self, mle_est: ParamDict):
+        super().__init__()
+        self.names = list(mle_est.keys())
+        for name, value in mle_est.items():
+            setattr(self, name + "_param", torch.nn.Parameter(value))
+
+    def forward(self, *args, **kwargs):
+        for name in self.names:
+            value = getattr(self, name + "_param")
+            pyro.sample(
+                name, pyro.distributions.Delta(value, event_dim=len(value.shape))
+            )
+
+
+def humansize(nbytes):
+    # Taken from:
+    # https://stackoverflow.com/questions/61462876/macos-activity-monitor-commands-cached-files-in-python
+    """Appends prefix to bytes for human readability."""
+
+    suffixes = ["B", "KB", "MB", "GB", "TB", "PB"]
+    i = 0
+    while nbytes >= 1024 and i < len(suffixes) - 1:
+        nbytes /= 1024.0
+        i += 1
+    f = ("%.2f" % nbytes).rstrip("0").rstrip(".")
+    return "%s %s" % (f, suffixes[i])
+
+
+N_pts = 500
+mu_true = 0.0
+sd_true = 1.0
+true_model = GroundTruthToyNormal(mu_true, sd_true)
+D_pts = Predictive(true_model, num_samples=N_pts, return_sites=["Y"])()
+Y_pts = D_pts["Y"]
+Y_pts = torch.sort(Y_pts).values
+
+for detach in [True, False]:
+    for i in range(25):
+        mem = psutil.virtual_memory()
+
+        theta_true = {
+            "mu": torch.tensor(mu_true, requires_grad=True),
+            "sd": torch.tensor(sd_true, requires_grad=True),
+        }
+        model = ToyNormal()
+        guide = MLEGuide(theta_true)
+
+        # Linearize model
+        monte_eif = linearize(
+            PredictiveModel(model, guide),
+            num_samples_outer=10000,
+            num_samples_inner=1,
+            detach=detach,
+        )({"Y": Y_pts})
+        memory_size = humansize(mem.free)
+        print(f"Iteration: {i}, Detached: {detach}, Free Memory: {memory_size}")
+    print("\n")


### PR DESCRIPTION
This PR adds an argument `detach` to `linearize` and `make_empirical_fisher_vp` to avoid an odd memory leak when gradients are not detached in `make_empirical_fisher_vp`. In case people would like to autodiff through `linearize` (e.g., for higher-order influence function computations), then `detach` should be set to `False`. 

Resolves #516.