### PR TITLE
Fixes for Pyro 1.9 compatibility

### DIFF
--- a/chirho/interventional/handlers.py
+++ b/chirho/interventional/handlers.py
@@ -118,4 +118,9 @@ class Interventions(Generic[T], pyro.poutine.messenger.Messenger):
         )
 
 
-do = pyro.poutine.handlers._make_handler(Interventions)[1]
+if isinstance(pyro.poutine.handlers._make_handler(Interventions), tuple):
+    do = pyro.poutine.handlers._make_handler(Interventions)[1]
+else:
+    @pyro.poutine.handlers._make_handler(Interventions)
+    def do(fn: Callable, actions: Mapping[Hashable, AtomicIntervention[T]]):
+        ...

--- a/chirho/observational/handlers/condition.py
+++ b/chirho/observational/handlers/condition.py
@@ -110,4 +110,10 @@ class Observations(Generic[T], ObserveNameMessenger):
                 self._current_site = None
 
 
-condition = pyro.poutine.handlers._make_handler(Observations)[1]
+if isinstance(pyro.poutine.handlers._make_handler(Observations), tuple):
+    # backwards compatibility
+    condition = pyro.poutine.handlers._make_handler(Observations)[1]
+else:
+    @pyro.poutine.handlers._make_handler(Observations)
+    def condition(fn: Callable, data: Mapping[str, Observation[T]]):
+        ...

--- a/tests/robust/test_handlers.py
+++ b/tests/robust/test_handlers.py
@@ -28,7 +28,7 @@ MODEL_TEST_CASES: List[ModelTestCase] = [
     (SimpleModel, lambda _: SimpleGuide(), {"y"}, None),
     pytest.param(
         SimpleModel,
-        pyro.infer.autoguide.AutoNormal,
+        lambda m: pyro.infer.autoguide.AutoNormal(pyro.poutine.block(hide=["y"])(m)),
         {"y"},
         1,
         marks=pytest.mark.xfail(

--- a/tests/robust/test_internals_linearize.py
+++ b/tests/robust/test_internals_linearize.py
@@ -69,13 +69,13 @@ MODEL_TEST_CASES: List[ModelTestCase] = [
     (SimpleModel, lambda _: SimpleGuide(), {"y"}, None),
     pytest.param(
         SimpleModel,
-        pyro.infer.autoguide.AutoNormal,
+        lambda m: pyro.infer.autoguide.AutoNormal(pyro.poutine.block(hide=["y",])(m)),
         {"y"},
         1,
-        marks=pytest.mark.xfail(
-            reason="torch.func autograd doesnt work with PyroParam"
-        ),
-    ),
+        marks=[
+            pytest.mark.xfail(reason="torch.func autograd doesnt work with PyroParam")
+        ] if tuple(map(int, pyro.__version__.split("+")[0].split(".")[:3])) <= (1, 8, 6) else [],
+    )
 ]
 
 
@@ -117,7 +117,7 @@ def test_nmc_param_influence_smoke(
     for k, v in test_datum_eif.items():
         assert not torch.isnan(v).any(), f"eif for {k} had nans"
         assert not torch.isinf(v).any(), f"eif for {k} had infs"
-        if not k.endswith("guide.loc_a"):
+        if not (k.endswith("guide.loc_a") or k.endswith("a_unconstrained")):
             assert not torch.isclose(
                 v, torch.zeros_like(v)
             ).all(), f"eif for {k} was zero"
@@ -162,7 +162,7 @@ def test_nmc_param_influence_vmap_smoke(
     for k, v in test_data_eif.items():
         assert not torch.isnan(v).any(), f"eif for {k} had nans"
         assert not torch.isinf(v).any(), f"eif for {k} had infs"
-        if not k.endswith("guide.loc_a"):
+        if not (k.endswith("guide.loc_a") or k.endswith("a_unconstrained")):
             assert not torch.isclose(
                 v, torch.zeros_like(v)
             ).all(), f"eif for {k} was zero"

--- a/tests/robust/test_ops.py
+++ b/tests/robust/test_ops.py
@@ -28,7 +28,7 @@ MODEL_TEST_CASES: List[ModelTestCase] = [
     (SimpleModel, lambda _: SimpleGuide(), {"y"}, None),
     pytest.param(
         SimpleModel,
-        pyro.infer.autoguide.AutoNormal,
+        lambda m: pyro.infer.autoguide.AutoNormal(pyro.poutine.block(hide=["y"])(m)),
         {"y"},
         1,
         marks=pytest.mark.xfail(


### PR DESCRIPTION
The upstream PR https://github.com/pyro-ppl/pyro/pull/3328 fixes the bug in #393.

This PR reenables test cases that were xfailed because of #393 and adds a couple of other compatibility fixes with the upcoming Pyro 1.9 release.