### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/chirho/__init__.py
+++ b/chirho/__init__.py
@@ -3,4 +3,4 @@
 Project short description.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 
 from setuptools import find_packages, setup
 
-VERSION = "0.2.0"
+VERSION = "0.3.0"
 
 try:
     long_description = open("README.rst", encoding="utf-8").read()
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         # if you add any additional libraries, please also
         # add them to `docs/source/requirements.txt`
-        "pyro-ppl>=1.8.5",
+        "pyro-ppl>=1.9.0",
     ],
     extras_require={
         "dynamical": DYNAMICAL_REQUIRE,


### PR DESCRIPTION
Also increases minimum Pyro version to 1.9.0

Blocked until linting and typechecking errors on `master` are fixed