### PR TITLE
Fix TorchDiffEq tensor broadcasting

### DIFF
--- a/chirho/dynamical/internals/backends/torchdiffeq.py
+++ b/chirho/dynamical/internals/backends/torchdiffeq.py
@@ -105,8 +105,11 @@ def _batched_odeint(
     # TODO support event_dim > 0
     event_dim = 0  # assume states are batches of values of rank event_dim
 
+    # Call deriv once to get the shape of the output.
+    dy0 = func(t[..., 0], y0)
+
     y0_batch_shape = torch.broadcast_shapes(
-        *(y0_.shape[: len(y0_.shape) - event_dim] for y0_ in y0)
+        *(dy0_.shape[: len(dy0_.shape) - event_dim] for dy0_ in dy0)
     )
 
     y0_expanded = tuple(

--- a/chirho/dynamical/internals/backends/torchdiffeq.py
+++ b/chirho/dynamical/internals/backends/torchdiffeq.py
@@ -105,11 +105,8 @@ def _batched_odeint(
     # TODO support event_dim > 0
     event_dim = 0  # assume states are batches of values of rank event_dim
 
-    # Call deriv once to get the shape of the output.
-    dy0 = func(t[..., 0], y0)
-
     y0_batch_shape = torch.broadcast_shapes(
-        *(dy0_.shape[: len(dy0_.shape) - event_dim] for dy0_ in dy0)
+        *(y0_.shape[: len(y0_.shape) - event_dim] for y0_ in y0)
     )
 
     y0_expanded = tuple(

--- a/tests/dynamical/test_solver.py
+++ b/tests/dynamical/test_solver.py
@@ -30,3 +30,13 @@ def test_backend_arg():
     with TorchDiffEq():
         result = simulate(sir, init_state, start_time, end_time)
     assert result is not None
+
+
+def test_torchdiffeq_broadcasting():
+    with pyro.plate("plate", 3):
+        sir = bayes_sir_model()
+        with TorchDiffEq():
+            result = simulate(sir, init_state, start_time, end_time)
+
+    assert result is not None
+


### PR DESCRIPTION
This small PR addresses #524 by calling the partially evaluated `deriv` method a single time to determine any tensor broadcasting that occurred inside of its body. We then take the resulting tensor shapes and use them to define the broadcasted tensor shapes of the input state.