### PR TITLE
Reuse non-default names across multiple splits in MultiWorldCounterfactual

### DIFF
--- a/chirho/counterfactual/handlers/counterfactual.py
+++ b/chirho/counterfactual/handlers/counterfactual.py
@@ -143,10 +143,14 @@ class MultiWorldCounterfactual(IndexPlatesMessenger, BaseCounterfactualMessenger
 
     @classmethod
     def _pyro_split(cls, msg: Dict[str, Any]) -> None:
-        name = msg["name"] if msg["name"] is not None else cls.default_name
-        index_plates = get_index_plates()
-        if name in index_plates:
-            name = f"{name}__dup_{len(index_plates)}"
+        if msg["name"] is None:
+            index_plates = get_index_plates()
+            if cls.default_name in index_plates:
+                name = f"{cls.default_name}__dup_{len(index_plates)}"
+            else:
+                name = cls.default_name
+        else:
+            name = msg["name"]
         msg["kwargs"]["name"] = msg["name"] = name
 
 

--- a/chirho/counterfactual/handlers/counterfactual.py
+++ b/chirho/counterfactual/handlers/counterfactual.py
@@ -139,16 +139,16 @@ class MultiWorldCounterfactual(IndexPlatesMessenger, BaseCounterfactualMessenger
         >>> assert(x_counterfactual_2.squeeze() == torch.tensor(2.))
     """
 
-    default_name: str = "intervened"
+    fresh_prefix: str = "__fresh_split__"
 
     @classmethod
     def _pyro_split(cls, msg: Dict[str, Any]) -> None:
         if msg["name"] is None:
             index_plates = get_index_plates()
-            if cls.default_name in index_plates:
-                name = f"{cls.default_name}__dup_{len(index_plates)}"
-            else:
-                name = cls.default_name
+            name, fresh_suffix = cls.fresh_prefix, len(index_plates)
+            while name in index_plates:
+                name = f"{cls.fresh_prefix}{fresh_suffix}"
+                fresh_suffix += 1
         else:
             name = msg["name"]
         msg["kwargs"]["name"] = msg["name"] = name
@@ -190,8 +190,8 @@ class TwinWorldCounterfactual(IndexPlatesMessenger, BaseCounterfactualMessenger)
         >>> assert(x.squeeze()[1] == torch.tensor(2.))
     """
 
-    default_name: str = "intervened"
+    fresh_prefix: str = "__fresh_split__"
 
     @classmethod
     def _pyro_split(cls, msg: Dict[str, Any]) -> None:
-        msg["kwargs"]["name"] = msg["name"] = cls.default_name
+        msg["kwargs"]["name"] = msg["name"] = cls.fresh_prefix

--- a/chirho/explainable/ops.py
+++ b/chirho/explainable/ops.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple, TypeVar
 
 import pyro
 
-from chirho.indexed.ops import IndexSet, cond_n
+from chirho.indexed.ops import IndexSet, cond_n, gather
 from chirho.interventional.ops import Intervention, intervene
 
 S = TypeVar("S")
@@ -35,8 +35,12 @@ def preempt(
         return obs
 
     name = kwargs.get("name", None)
-    act_values = {IndexSet(**{name: {0}}): obs}
+    obs_idx = IndexSet(**{name: {0}})
+    act_values = {obs_idx: gather(obs, obs_idx, **kwargs)}
     for i, act in enumerate(acts):
-        act_values[IndexSet(**{name: {i + 1}})] = intervene(obs, act, **kwargs)
+        act_idx = IndexSet(**{name: {i + 1}})
+        act_values[act_idx] = gather(
+            intervene(act_values[obs_idx], act, **kwargs), act_idx, **kwargs
+        )
 
     return cond_n(act_values, case, event_dim=kwargs.get("event_dim", 0))

--- a/chirho/explainable/ops.py
+++ b/chirho/explainable/ops.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple, TypeVar
 
 import pyro
 
-from chirho.indexed.ops import IndexSet, cond_n, gather
+from chirho.indexed.ops import IndexSet, cond_n
 from chirho.interventional.ops import Intervention, intervene
 
 S = TypeVar("S")
@@ -35,12 +35,8 @@ def preempt(
         return obs
 
     name = kwargs.get("name", None)
-    obs_idx = IndexSet(**{name: {0}})
-    act_values = {obs_idx: gather(obs, obs_idx, **kwargs)}
+    act_values = {IndexSet(**{name: {0}}): obs}
     for i, act in enumerate(acts):
-        act_idx = IndexSet(**{name: {i + 1}})
-        act_values[act_idx] = gather(
-            intervene(act_values[obs_idx], act, **kwargs), act_idx, **kwargs
-        )
+        act_values[IndexSet(**{name: {i + 1}})] = intervene(obs, act, **kwargs)
 
     return cond_n(act_values, case, event_dim=kwargs.get("event_dim", 0))

--- a/chirho/indexed/internals.py
+++ b/chirho/indexed/internals.py
@@ -29,6 +29,7 @@ def _gather_number(
     *,
     event_dim: Optional[int] = None,
     name_to_dim: Optional[Dict[Hashable, int]] = None,
+    **kwargs,
 ) -> Union[numbers.Number, torch.Tensor]:
     assert event_dim is None or event_dim == 0
     return gather(
@@ -43,6 +44,7 @@ def _gather_tensor(
     *,
     event_dim: Optional[int] = None,
     name_to_dim: Optional[Dict[Hashable, int]] = None,
+    **kwargs,
 ) -> torch.Tensor:
     if event_dim is None:
         event_dim = 0
@@ -52,6 +54,8 @@ def _gather_tensor(
 
     result = value
     for name, indices in indexset.items():
+        if name not in name_to_dim:
+            continue
         dim = name_to_dim[name] - event_dim
         if len(result.shape) < -dim or result.shape[dim] == 1:
             continue

--- a/tests/counterfactual/test_mediation.py
+++ b/tests/counterfactual/test_mediation.py
@@ -171,12 +171,10 @@ def test_mediation_nde_smoke():
 
     # natural direct effect: DE{x,x'}(Y) = E[ Y(X=x', Z(X=x)) - E[Y(X=x)] ]
     def direct_effect(model, x, x_prime, w_obs, x_obs, z_obs, y_obs) -> Callable:
-        return do(actions={"X": x})(
-            do(actions={"X": x_prime})(
-                do(actions={"Z": lambda Z: Z})(
-                    condition(data={"W": w_obs, "X": x_obs, "Z": z_obs, "Y": y_obs})(
-                        pyro.plate("data", size=y_obs.shape[-1], dim=-1)(model)
-                    )
+        return do(actions={"X": (x, x_prime)})(
+            do(actions={"Z": lambda Z: Z})(
+                condition(data={"W": w_obs, "X": x_obs, "Z": z_obs, "Y": y_obs})(
+                    pyro.plate("data", size=y_obs.shape[-1], dim=-1)(model)
                 )
             )
         )
@@ -196,9 +194,9 @@ def test_mediation_nde_smoke():
         W, X, Z, Y = extended_model()
 
     assert W.shape == (N,)
-    assert X.shape == (2, 2, N)
-    assert Z.shape == (2, 2, 2, N)
-    assert Y.shape == (2, 2, 2, N)
+    assert X.shape == (3, N)
+    assert Z.shape == (2, 3, N)
+    assert Y.shape == (2, 3, N)
 
 
 @pytest.mark.parametrize("cf_dim", [-1, -2, -3, None])

--- a/tests/dynamical/test_dynamic_interventions.py
+++ b/tests/dynamical/test_dynamic_interventions.py
@@ -267,8 +267,8 @@ def test_split_twinworld_dynamic_intervention(
         cf_trajectory = dt.trajectory
         for k in cf_trajectory.keys():
             # TODO: Figure out why event_dim=1 is not needed with cf_state but is with cf_trajectory.
-            assert cf.default_name in indices_of(cf_state[k])
-            assert cf.default_name in indices_of(cf_trajectory[k], event_dim=1)
+            assert cf.fresh_prefix in indices_of(cf_state[k])
+            assert cf.fresh_prefix in indices_of(cf_trajectory[k], event_dim=1)
 
 
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
@@ -314,8 +314,8 @@ def test_split_multiworld_dynamic_intervention(
         cf_trajectory = dt.trajectory
         for k in cf_trajectory.keys():
             # TODO: Figure out why event_dim=1 is not needed with cf_state but is with cf_trajectory.
-            assert cf.default_name in indices_of(cf_state[k])
-            assert cf.default_name in indices_of(cf_trajectory[k], event_dim=1)
+            assert cf.fresh_prefix in indices_of(cf_state[k])
+            assert cf.fresh_prefix in indices_of(cf_trajectory[k], event_dim=1)
 
 
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])

--- a/tests/dynamical/test_static_interventions.py
+++ b/tests/dynamical/test_static_interventions.py
@@ -214,8 +214,8 @@ def test_twinworld_point_intervention(
         cf_trajectory = dt.trajectory
         for k in cf_trajectory.keys():
             # TODO: Figure out why event_dim=1 is not needed with cf_state but is with cf_trajectory.
-            assert cf.default_name in indices_of(cf_state[k])
-            assert cf.default_name in indices_of(cf_trajectory[k], event_dim=1)
+            assert cf.fresh_prefix in indices_of(cf_state[k])
+            assert cf.fresh_prefix in indices_of(cf_trajectory[k], event_dim=1)
 
 
 @pytest.mark.skip(
@@ -251,8 +251,8 @@ def test_multiworld_point_intervention(
         cf_trajectory = dt.trajectory
         for k in cf_trajectory.keys():
             # TODO: Figure out why event_dim=1 is not needed with cf_state but is with cf_trajectory.
-            assert cf.default_name in indices_of(cf_state[k])
-            assert cf.default_name in indices_of(cf_trajectory[k], event_dim=1)
+            assert cf.fresh_prefix in indices_of(cf_state[k])
+            assert cf.fresh_prefix in indices_of(cf_trajectory[k], event_dim=1)
 
 
 @pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])


### PR DESCRIPTION
This PR changes the behavior of the `MultiWorldCounterfactual` handler. Previously, `MultiWorldCounterfactual` created a fresh index variable for every `split()` call, regardless of the `name` keyword argument passed to `split`. After this PR, `MultiWorldCounterfactual` only introduces fresh variables for fresh (or empty) names.

This change is necessary to support a more sophisticated counterfactual semantics in dynamical systems.