### PR TITLE
Separate influence function approximation from `influence_fn` syntax using handlers

### DIFF
--- a/chirho/robust/ops.py
+++ b/chirho/robust/ops.py
@@ -1,7 +1,6 @@
-import warnings
 from typing import Any, Callable, Mapping, Protocol, TypeVar
 
-import torch
+import pyro
 from typing_extensions import ParamSpec
 
 from chirho.observational.ops import Observation
@@ -20,6 +19,7 @@ class Functional(Protocol[P, S]):
     ) -> Callable[P, S]: ...
 
 
+@pyro.poutine.runtime.effectful(type="influence_fn")
 def influence_fn(
     functional: Functional[P, S], *points: Point[T], **linearize_kwargs
 ) -> Functional[P, S]:
@@ -40,6 +40,7 @@ def influence_fn(
             import torch
 
             from chirho.robust.handlers.predictive import PredictiveModel
+            from chirho.robust.handlers.estimators import MonteCarloInfluenceEstimator
             from chirho.robust.ops import influence_fn
 
             pyro.settings.set(module_local_params=True)
@@ -84,78 +85,25 @@ def influence_fn(
                 model, guide=guide, num_samples=10, return_sites=["y"]
             )
             points = predictive()
-            influence = influence_fn(
-                SimpleFunctional,
-                points,
-                num_samples_outer=1000,
-                num_samples_inner=1000,
-            )(PredictiveModel(model, guide))
+            with MonteCarloInfluenceEstimator(num_samples_inner=1000, num_samples_outer=1000):
+                influence = influence_fn(
+                    SimpleFunctional,
+                    points,
+                )(PredictiveModel(model, guide))
 
             with torch.no_grad():  # Avoids memory leak (see notes below)
                 influence()
 
     .. note::
 
-        * ``functional`` must compose with ``torch.func.jvp``
-        * Since the efficient influence function is approximated using Monte Carlo, the result
-          of this function is stochastic, i.e., evaluating this function on the same ``points``
-          can result in different values. To reduce variance, increase ``num_samples_outer`` and
-          ``num_samples_inner`` in ``linearize_kwargs``.
-        * Currently, ``model`` cannot contain any ``pyro.param`` statements.
-          This issue will be addressed in a future release:
-          https://github.com/BasisResearch/chirho/issues/393.
         * There are memory leaks when calling this function multiple times due to ``torch.func``.
           See issue:
           https://github.com/BasisResearch/chirho/issues/516.
           To avoid this issue, use ``torch.no_grad()`` as shown in the example above.
 
     """
-    from chirho.robust.internals.linearize import linearize
-    from chirho.robust.internals.utils import make_functional_call
 
-    if len(points) != 1:
-        raise NotImplementedError(
-            "influence_fn currently only supports unary functionals"
-        )
-
-    def _influence_functional(*models: Callable[P, Any]) -> Callable[P, S]:
-        """
-        Functional representing the efficient influence function of ``functional`` at ``points`` .
-
-        :param models: Python callables containing Pyro primitives.
-        :return: efficient influence function for ``functional`` evaluated at ``model`` and ``points``
-        """
-        if len(models) != len(points):
-            raise ValueError("mismatch between number of models and points")
-
-        linearized = linearize(*models, **linearize_kwargs)
-        target = functional(*models)
-
-        # TODO check that target_params == model_params
-        assert isinstance(target, torch.nn.Module)
-        target_params, func_target = make_functional_call(target)
-
-        def _fn(*args: P.args, **kwargs: P.kwargs) -> S:
-            """
-            Evaluates the efficient influence function for ``functional`` at each
-            point in ``points``.
-
-            :return: efficient influence function evaluated at each point in ``points`` or averaged
-            """
-            if torch.is_grad_enabled():
-                warnings.warn(
-                    "Calling influence_fn with torch.grad enabled can lead to memory leaks. "
-                    "Please use torch.no_grad() to avoid this issue. See example in the docstring."
-                )
-            param_eif = linearized(*points, *args, **kwargs)
-            return torch.vmap(
-                lambda d: torch.func.jvp(
-                    lambda p: func_target(p, *args, **kwargs), (target_params,), (d,)
-                )[1],
-                in_dims=0,
-                randomness="different",
-            )(param_eif)
-
-        return _fn
-
-    return _influence_functional
+    raise NotImplementedError(
+        "Evaluating the `influence_fn` requires an either (i) an approximation method such as `MonteCarloInfluenceEstimator`"
+        "or (ii) a custom handler for the specific model and functional."
+    )

--- a/tests/robust/test_handlers/test_MC_EIF.py
+++ b/tests/robust/test_handlers/test_MC_EIF.py
@@ -11,7 +11,7 @@ from chirho.robust.handlers.estimators import MonteCarloInfluenceEstimator
 from chirho.robust.handlers.predictive import PredictiveFunctional, PredictiveModel
 from chirho.robust.ops import influence_fn
 
-from .robust_fixtures import SimpleGuide, SimpleModel
+from ..robust_fixtures import SimpleGuide, SimpleModel
 
 pyro.settings.set(module_local_params=True)
 

--- a/tests/robust/test_handlers/test_estimators.py
+++ b/tests/robust/test_handlers/test_estimators.py
@@ -6,10 +6,13 @@ import pytest
 import torch
 from typing_extensions import ParamSpec
 
-from chirho.robust.handlers.estimators import one_step_corrected_estimator
+from chirho.robust.handlers.estimators import (
+    MonteCarloInfluenceEstimator,
+    one_step_corrected_estimator,
+)
 from chirho.robust.handlers.predictive import PredictiveFunctional, PredictiveModel
 
-from .robust_fixtures import SimpleGuide, SimpleModel
+from ..robust_fixtures import SimpleGuide, SimpleModel
 
 pyro.settings.set(module_local_params=True)
 
@@ -69,14 +72,16 @@ def test_estimator_smoke(
             )().items()
         }
 
-    estimator = estimation_method(
-        functools.partial(PredictiveFunctional, num_samples=num_predictive_samples),
-        test_datum,
+    with MonteCarloInfluenceEstimator(
         max_plate_nesting=max_plate_nesting,
         num_samples_outer=num_samples_outer,
         num_samples_inner=num_samples_inner,
         cg_iters=cg_iters,
-    )(PredictiveModel(model, guide))
+    ):
+        estimator = estimation_method(
+            functools.partial(PredictiveFunctional, num_samples=num_predictive_samples),
+            test_datum,
+        )(PredictiveModel(model, guide))
 
     estimate_on_test: Mapping[str, torch.Tensor] = estimator()
     assert len(estimate_on_test) > 0

--- a/tests/robust/test_handlers/test_estimators.py
+++ b/tests/robust/test_handlers/test_estimators.py
@@ -72,18 +72,18 @@ def test_estimator_smoke(
             )().items()
         }
 
+    estimator = estimation_method(
+        functools.partial(PredictiveFunctional, num_samples=num_predictive_samples),
+        test_datum,
+    )(PredictiveModel(model, guide))
+
     with MonteCarloInfluenceEstimator(
         max_plate_nesting=max_plate_nesting,
         num_samples_outer=num_samples_outer,
         num_samples_inner=num_samples_inner,
         cg_iters=cg_iters,
     ):
-        estimator = estimation_method(
-            functools.partial(PredictiveFunctional, num_samples=num_predictive_samples),
-            test_datum,
-        )(PredictiveModel(model, guide))
-
-    estimate_on_test: Mapping[str, torch.Tensor] = estimator()
+        estimate_on_test: Mapping[str, torch.Tensor] = estimator()
     assert len(estimate_on_test) > 0
     for k, v in estimate_on_test.items():
         assert not torch.isnan(v).any(), f"{estimation_method} for {k} had nans"


### PR DESCRIPTION
This refactoring PR separates out the influence_fn operation, which can be used in a way that is approximation-agnostic, from the effect handlers that implement their approximation.

In particular, this extracts what was previously included in the influence_fn operation and ports that functionality into a new MonteCarloInfluenceEstimator effect handler.

In addition, this PR modifies the tests and some documentation to reflect these changes.

Subsumes #478.