### PR TITLE
Revise counterfactual tests to use `indexed` operations.

### DIFF
--- a/tests/counterfactual/test_counterfactual_handler.py
+++ b/tests/counterfactual/test_counterfactual_handler.py
@@ -48,25 +48,20 @@ def test_counterfactual_handler_smoke(x_cf_value, cf_dim):
 
     with SingleWorldFactual():
         z_factual, x_factual, y_factual = model()
-
-    assert x_factual != x_cf_value
-    assert z_factual.shape == x_factual.shape == y_factual.shape == torch.Size([])
+        assert indices_of(z_factual) == indices_of(x_factual) == indices_of(y_factual) == IndexSet()
+        assert x_factual != x_cf_value
 
     with SingleWorldCounterfactual():
         z_cf, x_cf, y_cf = model()
-
-    assert x_cf == x_cf_value
-    assert z_cf.shape == x_cf.shape == y_cf.shape == torch.Size([])
+        assert indices_of(z_cf) == indices_of(x_cf) == indices_of(y_cf) == IndexSet()
+        assert x_cf == x_cf_value
 
     with TwinWorldCounterfactual(cf_dim):
         z_cf_twin, x_cf_twin, y_cf_twin = model()
-
-    assert torch.all(x_cf_twin[0] != x_cf_value)
-    assert torch.all(x_cf_twin[1] == x_cf_value)
-    assert z_cf_twin.shape == torch.Size([])
-    assert (
-        x_cf_twin.shape == y_cf_twin.shape == (2,) + (1,) * (len(y_cf_twin.shape) - 1)
-    )
+        assert indices_of(z_cf_twin) == IndexSet()
+        assert indices_of(x_cf_twin) == indices_of(y_cf_twin) == IndexSet(__fresh_split__={0, 1})
+        assert gather(x_cf_twin, IndexSet(__fresh_split__={0})) != x_cf_value
+        assert gather(x_cf_twin, IndexSet(__fresh_split__={1})) == x_cf_value
 
 
 @pytest.mark.parametrize("num_splits", [1, 2, 3])

--- a/tests/counterfactual/test_mediation.py
+++ b/tests/counterfactual/test_mediation.py
@@ -201,10 +201,10 @@ def test_mediation_nde_smoke():
     with MultiWorldCounterfactual(-2):
         W, X, Z, Y = extended_model()
 
-    assert W.shape == (N,)
-    assert X.shape == (3, N)
-    assert Z.shape == (2, 3, N)
-    assert Y.shape == (2, 3, N)
+        assert indices_of(W) == IndexSet()
+        assert indices_of(X) == IndexSet(X={0, 1, 2})
+        assert indices_of(Z) == IndexSet(X={0, 1, 2}, Z={0, 1})
+        assert indices_of(Y) == IndexSet(X={0, 1, 2}, Z={0, 1})
 
 
 @pytest.mark.parametrize("cf_dim", [-1, -2, -3, None])
@@ -217,9 +217,9 @@ def test_mediation_dependent_intervention(cf_dim, cf_value):
     with MultiWorldCounterfactual(cf_dim):
         W, X, Z, Y = intervened_model()
 
-    assert W.shape == ()
-    assert X.shape == ()
-    assert Z.shape == (2,) + (1,) * (len(Z.shape) - 1)
-    assert Y.shape == (2,) + (1,) * (len(Y.shape) - 1)
+        assert indices_of(W) == IndexSet()
+        assert indices_of(X) == IndexSet()
+        assert indices_of(Z) == IndexSet(Z={0, 1})
+        assert indices_of(Y) == IndexSet(Z={0, 1})
 
-    assert torch.all(Z[1] == (Z[0] + cf_value))
+        assert gather(Z, IndexSet(Z={1})) == (gather(Z, IndexSet(Z={0})) + cf_value)

--- a/tests/counterfactual/test_mediation.py
+++ b/tests/counterfactual/test_mediation.py
@@ -82,12 +82,24 @@ def test_do_api(x_cf_value):
 
         # Checking equality on each element is probably overkill, but may be nice for debugging tests later...
         assert W_1 != W_2
-        assert gather(X_1, IndexSet(__fresh_split__={0})) != gather(X_2, IndexSet(__fresh_split__={0}))  # Sampled with fresh randomness each time
-        assert gather(X_1, IndexSet(__fresh_split__={1})) == gather(X_2, IndexSet(__fresh_split__={1}))  # Intervention assignment should be equal
-        assert gather(Z_1, IndexSet(__fresh_split__={0})) != gather(Z_2, IndexSet(__fresh_split__={0}))  # Sampled with fresh randomness each time
-        assert gather(Z_1, IndexSet(__fresh_split__={1})) != gather(Z_2, IndexSet(__fresh_split__={1}))  # Counterfactual, but with different exogenous noise
-        assert gather(Y_1, IndexSet(__fresh_split__={0})) != gather(Y_2, IndexSet(__fresh_split__={0}))  # Sampled with fresh randomness each time
-        assert gather(Y_1, IndexSet(__fresh_split__={1})) != gather(Y_2, IndexSet(__fresh_split__={1}))  # Counterfactual, but with different exogenous noise
+        assert gather(X_1, IndexSet(__fresh_split__={0})) != gather(
+            X_2, IndexSet(__fresh_split__={0})
+        )  # Sampled with fresh randomness each time
+        assert gather(X_1, IndexSet(__fresh_split__={1})) == gather(
+            X_2, IndexSet(__fresh_split__={1})
+        )  # Intervention assignment should be equal
+        assert gather(Z_1, IndexSet(__fresh_split__={0})) != gather(
+            Z_2, IndexSet(__fresh_split__={0})
+        )  # Sampled with fresh randomness each time
+        assert gather(Z_1, IndexSet(__fresh_split__={1})) != gather(
+            Z_2, IndexSet(__fresh_split__={1})
+        )  # Counterfactual, but with different exogenous noise
+        assert gather(Y_1, IndexSet(__fresh_split__={0})) != gather(
+            Y_2, IndexSet(__fresh_split__={0})
+        )  # Sampled with fresh randomness each time
+        assert gather(Y_1, IndexSet(__fresh_split__={1})) != gather(
+            Y_2, IndexSet(__fresh_split__={1})
+        )  # Counterfactual, but with different exogenous noise
 
 
 @pytest.mark.parametrize("x_cf_value", x_cf_values)
@@ -99,10 +111,18 @@ def test_linear_mediation_unconditioned(x_cf_value):
     with TwinWorldCounterfactual(-1):
         W, X, Z, Y = intervened_model()
 
-    # Noise should be shared between factual and counterfactual outcomes
-    # Some numerical precision issues getting these exactly equal
-    assert isclose((Z - X - W)[0], (Z - X - W)[1], abs_tol=1e-5)
-    assert isclose((Y - Z - X - W)[0], (Y - Z - X - W)[1], abs_tol=1e-5)
+        # Noise should be shared between factual and counterfactual outcomes
+        # Some numerical precision issues getting these exactly equal
+        assert isclose(
+            gather((Z - X - W), IndexSet(__fresh_split__={0})),
+            gather((Z - X - W), IndexSet(__fresh_split__={1})),
+            abs_tol=1e-5,
+        )
+        assert isclose(
+            gather(Y - Z - X - W, IndexSet(__fresh_split__={0})),
+            gather(Y - Z - X - W, IndexSet(__fresh_split__={1})),
+            abs_tol=1e-5,
+        )
 
 
 @pytest.mark.parametrize("x_cf_value", x_cf_values)
@@ -118,8 +138,8 @@ def test_linear_mediation_conditioned(x_cf_value):
     with TwinWorldCounterfactual(-1):
         W, X, Z, Y = intervened_model()
 
-    assert X[0] == x_cond_value
-    assert X[1] == x_cf_value
+        assert gather(X, IndexSet(__fresh_split__={0})) == x_cond_value
+        assert gather(X, IndexSet(__fresh_split__={1})) == x_cf_value
 
 
 @pytest.mark.parametrize("x_cf_value", x_cf_values)

--- a/tests/counterfactual/test_mediation.py
+++ b/tests/counterfactual/test_mediation.py
@@ -168,10 +168,10 @@ def test_multiple_interventions(x_cf_value):
     with MultiWorldCounterfactual(-1):
         W, X, Z, Y = intervened_model()
 
-    assert W.shape == ()
-    assert X.shape == (2,)
-    assert Z.shape == (2, 2)
-    assert Y.shape == (2, 2)
+        assert indices_of(W) == IndexSet()
+        assert indices_of(X) == IndexSet(X={0, 1})
+        assert indices_of(Z) == IndexSet(X={0, 1}, Z={0, 1})
+        assert indices_of(Y) == IndexSet(X={0, 1}, Z={0, 1})
 
 
 def test_mediation_nde_smoke():


### PR DESCRIPTION
Addresses #203 .

This simple PR refactors our existing tests in `test_counterfactual` to use the more recent operations for indexing into counterfactual worlds from the `indexed` module.