### PR TITLE
Update explainable_categorical.ipynb

### DIFF
--- a/docs/source/explainable_categorical.ipynb
+++ b/docs/source/explainable_categorical.ipynb
@@ -292,7 +292,7 @@
     "Throughout this tutorial, we assume all nodes are binary and use $'$ as negation. Once we specify (i) the distributions for the nodes we use (`supports`), (ii) candidate causes $X_i = x_i$ (`antecedents`) (iii) their alternative values ($X_i = x_i'$), (iv) elements of the current context (`witnesses`), and  (v) the `consequents` of interest $Y=y$. The  `SearchForExplanation` handler transforms the original model into one in which interventions and alternative interventions on the antecedents are applied in parallel counterfactual worlds stochastically preempted and context elements are stochastically selected and preempted to be kept at the factual values in all counterfactual worlds.\n",
     "\n",
     "First, let's go back to our original query. Let $F$ be the `forest_fire`, $f$ stand for $F=1$, $f'$ for $F=0$, $M$ stand for `match_dropped`, with analogous conventions. We also place interventions conditioned on in subscripts, so that, for example\n",
-    "$P(f_m')$ stands for $P(F=1\\vert do(M=0))$.\n",
+    "$P(f_{m'})$ stands for $P(F=1\\vert do(M=0))$.\n",
     "\n",
     "We are currently interested in $P(f'_{m'}, f_m)$, that is the probability of both forest fire not occurring if we intervene on the match to not be dropped, and forest fire occurring if we intervene on the match to be dropped."
    ]


### PR DESCRIPTION
braces were missing around `m'` such that `P(f_m')` rendered incorrectly as $P(f_m')$ which is equivalent to  $P(F=0 | do(M=1))$ instead of `P(f_{m'})` rendering as $P(f_{m'})$ which is equivalent to $P(F=1|do(M=0))$ as intended