### PR TITLE
Pin mypy to 1.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
             "pytest",
             "pytest-cov",
             "pytest-xdist",
-            "mypy",
+            "mypy==1.10",
             "black",
             "flake8",
             "isort",


### PR DESCRIPTION
Mypy 1.11 introduces new typing errors. Without this, lint fails on a fresh clone.