### PR TITLE
Support for `intervene` operations on dictionaries where `act` is a Callable

### DIFF
--- a/tests/dynamical/test_static_interventions.py
+++ b/tests/dynamical/test_static_interventions.py
@@ -34,6 +34,7 @@ intervene_states = [
     dict(I=torch.tensor(50.0)),
     dict(S=torch.tensor(50.0), R=torch.tensor(50.0)),
     dict(S=torch.tensor(50.0), I=torch.tensor(50.0), R=torch.tensor(50.0)),
+    lambda X: {k: v / 2 for k, v in X.items()},
 ]
 
 # Define intervention times before all tspan values.


### PR DESCRIPTION
This PR provides support for the case where we want to apply an intervention on dictionaries where `act` is a function from `Dict[K, T]` to `Dict[K, T]`. This is useful for applying slightly more sophisticated interventions in dynamical systems, where intervention assignments on one state variable may dependent on the value of another.

Specifically, this PR adds new logic to `intervene`'s dispatch on dictionaries, calling a newly added effectful instance of `intervene`. In addition, this PR adds a new dispatch of `scatter` for dictionaries which calls `scatter` on each of the dictionaries values. Finally, this PR adds a new test case to the `dynamical` test suite where an intervention is assigned as a function from state to state. This implicitly tests the new interventions composition with various counterfactual handlers.