### PR TITLE
Address linting errors in `dynamical`

### DIFF
--- a/chirho/dynamical/handlers/interruption.py
+++ b/chirho/dynamical/handlers/interruption.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import numbers
 import typing
 from typing import Callable, Generic, Tuple, TypeVar, Union
 

--- a/chirho/dynamical/handlers/interruption.py
+++ b/chirho/dynamical/handlers/interruption.py
@@ -14,7 +14,7 @@ from chirho.indexed.ops import cond
 from chirho.interventional.ops import Intervention, intervene
 from chirho.observational.ops import Observation, observe
 
-R = Union[numbers.Real, torch.Tensor]
+R = Union[float, torch.Tensor]
 S = TypeVar("S")
 T = TypeVar("T")
 

--- a/chirho/dynamical/internals/solver.py
+++ b/chirho/dynamical/internals/solver.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import heapq
 import math
-import numbers
 import typing
 import warnings
 from typing import Callable, Generic, List, Optional, Tuple, TypeVar, Union

--- a/chirho/dynamical/internals/solver.py
+++ b/chirho/dynamical/internals/solver.py
@@ -13,7 +13,7 @@ import torch
 from chirho.dynamical.internals._utils import Prioritized, ShallowMessenger
 from chirho.dynamical.ops import Dynamics, State, on
 
-R = Union[numbers.Real, torch.Tensor]
+R = Union[float, torch.Tensor]
 S = TypeVar("S")
 T = TypeVar("T")
 

--- a/chirho/dynamical/ops.py
+++ b/chirho/dynamical/ops.py
@@ -94,7 +94,7 @@ def on(
     if callback is None:
 
         def _on(
-            callback: Callable[[Dynamics[T], State[T]], Tuple[Dynamics[T], State[T]]]
+            callback: Callable[[Dynamics[T], State[T]], Tuple[Dynamics[T], State[T]]],
         ):
             return on(predicate, callback)
 

--- a/chirho/robust/internals/utils.py
+++ b/chirho/robust/internals/utils.py
@@ -196,7 +196,7 @@ def pytree_generalized_manual_revjvp(
 
 
 def make_functional_call(
-    mod: Callable[P, T]
+    mod: Callable[P, T],
 ) -> Tuple[ParamDict, Callable[Concatenate[ParamDict, P], T]]:
     """
     Converts a PyTorch module into a functional call for use with


### PR DESCRIPTION
This tiny PR addresses linting errors due to PyTorch refining its types in version 2.6.0.