### PR TITLE
Fix bug in `dynamical` module when two dynamic interventions occur at the same time

### DIFF
--- a/chirho/dynamical/internals/backends/torchdiffeq.py
+++ b/chirho/dynamical/internals/backends/torchdiffeq.py
@@ -245,9 +245,12 @@ def torchdiffeq_simulate_to_interruption(
 ) -> Tuple[State[torch.Tensor], torch.Tensor, Optional[Interruption[torch.Tensor]]]:
     assert len(interruptions) > 0, "should have at least one interruption here"
 
-    (next_interruption,), interruption_time = _torchdiffeq_get_next_interruptions(
+    next_interruptions, interruption_time = _torchdiffeq_get_next_interruptions(
         dynamics, initial_state, start_time, interruptions, **kwargs
     )
+
+    # Choose one arbitrarily if there are multiple.
+    next_interruption = next_interruptions[0]
 
     value = simulate_point(
         dynamics, initial_state, start_time, interruption_time, **kwargs

--- a/tests/dynamical/test_dynamic_interventions.py
+++ b/tests/dynamical/test_dynamic_interventions.py
@@ -237,6 +237,42 @@ def test_dynamic_intervention_causes_change(
 @pytest.mark.parametrize("start_time", [start_time])
 @pytest.mark.parametrize("end_time", [end_time])
 @pytest.mark.parametrize("logging_times", [logging_times])
+@pytest.mark.parametrize("trigger_state", [trigger_state1])
+@pytest.mark.parametrize("intervene_state", [intervene_state1])
+@pytest.mark.parametrize("event_fn_builder", [get_state_reached_event_f])
+def test_dynamic_intervention_collision(
+    solver,
+    model,
+    init_state,
+    start_time,
+    end_time,
+    logging_times,
+    trigger_state,
+    intervene_state,
+    event_fn_builder,
+):
+
+    with LogTrajectory(
+        times=logging_times,
+    ):
+        with solver():
+            with DynamicIntervention(
+                event_fn=event_fn_builder(trigger_state),
+                intervention=intervene_state,
+            ):
+                with DynamicIntervention(
+                    event_fn=event_fn_builder(trigger_state),
+                    intervention=intervene_state,
+                ):
+                    simulate(model, init_state, start_time, end_time)
+
+
+@pytest.mark.parametrize("solver", [TorchDiffEq])
+@pytest.mark.parametrize("model", [UnifiedFixtureDynamics()])
+@pytest.mark.parametrize("init_state", [init_state])
+@pytest.mark.parametrize("start_time", [start_time])
+@pytest.mark.parametrize("end_time", [end_time])
+@pytest.mark.parametrize("logging_times", [logging_times])
 @pytest.mark.parametrize(
     "trigger_states",
     [(trigger_state1, trigger_state2), (trigger_state2, trigger_state1)],


### PR DESCRIPTION
This small PR fixes a tuple unpacking bug when two dynamic events occur at the same time. This PR first adds a (previously failing) test case, where a dynamic intervention is applied twice, and therefore automatically triggers twice at the same time. This PR also introduces a fix where we arbitrarily choose the first element of the tuple of interventions triggered.

CI failure is blocked by #579 and #581