### PR TITLE
Bump deprecated GitHub CI actions and cache v1/v2 to v4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: [3.9, '3.10', 3.11]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: pip cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: lint-pip-${{ hashFiles('**/pyproject.toml') }}
@@ -25,7 +25,7 @@ jobs:
             lint-pip-
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
         os: [ubuntu-latest]  # , macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Ubuntu cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         if: startsWith(matrix.os, 'ubuntu')
         with:
           path: ~/.cache/pip
@@ -28,7 +28,7 @@ jobs:
             ${{ matrix.os }}-${{ matrix.python-version }}-
 
       - name: macOS cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         if: startsWith(matrix.os, 'macOS')
         with:
           path: ~/Library/Caches/pip
@@ -38,7 +38,7 @@ jobs:
             ${{ matrix.os }}-${{ matrix.python-version }}-
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test_notebooks.yml
+++ b/.github/workflows/test_notebooks.yml
@@ -19,17 +19,17 @@ jobs:
         python-version: [3.9]
 
     steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
 
         - name: pip cache
-          uses: actions/cache@v2
+          uses: actions/cache@v4
           with:
             path: ~/.cache/pip
             key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
 
 
         - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v1
+          uses: actions/setup-python@v4
           with:
             python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
See title

CI linting failure is blocked by #579 