### PR TITLE
Differentiable masks for `BatchedAction`

### DIFF
--- a/chirho/counterfactual/handlers/counterfactual.py
+++ b/chirho/counterfactual/handlers/counterfactual.py
@@ -206,78 +206,74 @@ _DEFAULT_BATCH_NAME = "batched_interventions"
 
 @dataclasses.dataclass
 class BatchedAction:
-    """Per-site batched intervention for use with :class:`BatchedWorldCounterfactual`.
+    """Per-site batched intervention for :class:`BatchedWorldCounterfactual`.
 
-    :param act: Shape ``(N, *event_shape)``. Intervention value for each scenario.
-    :param mask: Shape ``(N,)``, bool or floating point. Which scenarios intervene on
-        this site. Defaults to all-True.
-    :param validate_args: If True, check that a floating point ``mask`` lies in ``[0, 1]``.
+    :param act: Intervention values, shape ``(*batch, N, *event_shape)``.
+        ``N = act.shape[-(event_dim + 1)]``.
+    :param mask: Shape ``(*batch, N)``, bool or float. Selects which scenarios
+        intervene on this site. Defaults to all-True.
+    :param event_dim: Event dimensions trailing N in ``act``. Default 0.
 
-    A bool ``mask`` gates. ``torch.where`` never reads slots where it is ``False``,
-    so their ``act`` values are irrelevant placeholders.
+    A bool mask gates: ``False`` slots return the factual value, their ``act``
+    entries ignored.
 
-    A floating point ``mask`` ``w`` blends, ``w * act + (1 - w) * obs``, and passes
-    gradient to both ``act`` and ``w``. Autograd rejects ``requires_grad`` on bool, so
-    a floating point dtype is the only way to learn a mask. Values of exactly 0 or 1
-    match the bool path bit for bit; that is the intended use, typically via a
-    straight-through estimator. Intermediate values give a soft intervention, and
-    identification results that assume atomic interventions no longer hold. Values
-    outside ``[0, 1]`` extrapolate. The blend multiplies both branches instead of
-    picking one, so it requires a floating point site and finite ``act`` and ``obs``.
-    Integer masks raise.
+    A float mask ``w`` blends: ``w * act + (1 - w) * obs``, with gradient flowing
+    to both ``act`` and ``w``. Values 0 and 1 are bit-identical to the bool gate.
+    The intended pattern is a straight-through estimator: a hard 0/1 mask on the
+    forward pass with gradient flowing back through the soft branch to upstream
+    log-probabilities. Intermediate values give a soft blend; identification results
+    assuming atomic interventions no longer hold. Integer masks raise.
 
-    All ``BatchedAction`` objects in a single run must share the same leading size N.
+    All :class:`BatchedAction` objects in a single run must share the same N.
     """
 
     act: torch.Tensor
     mask: torch.Tensor
+    event_dim: int
 
     def __init__(
         self,
         act: torch.Tensor,
         mask: torch.Tensor | None = None,
         *,
-        validate_args: bool = False,
+        event_dim: int = 0,
     ):
         self.act = act
+        self.event_dim = event_dim
+
+        n = act.shape[-(event_dim + 1)]
         if mask is None:
-            self.mask = torch.ones(self.act.shape[0], dtype=torch.bool)
+            batch_shape = act.shape[: act.ndim - event_dim - 1]
+            self.mask = act.new_ones(batch_shape + (n,), dtype=torch.bool)
             return
 
-        if self.act.shape[0] != mask.shape[0]:
-            raise ValueError(
-                f"act and mask must have the same leading dimension, "
-                f"got act.shape[0]={self.act.shape[0]} and mask.shape[0]={mask.shape[0]}."
-            )
+        if mask.shape[-1] != n:
+            raise ValueError(f"mask's last dimension must match N={n}, got mask.shape[-1]={mask.shape[-1]}.")
         if mask.dtype is not torch.bool and not mask.is_floating_point():
             raise ValueError(f"mask must be bool or floating point, got dtype {mask.dtype}.")
-        if validate_args and mask.is_floating_point() and not ((mask >= 0.0) & (mask <= 1.0)).all():
-            raise ValueError("floating point mask must lie in [0, 1].")
         self.mask = mask
 
     @property
     def batch_size(self) -> int:
-        return self.act.shape[0]
+        return self.act.shape[-(self.event_dim + 1)]
 
 
 def _prepend_factual_world(action: BatchedAction) -> BatchedAction:
     """Prepend a factual world at index 0 (mask=False, so obs passes through unchanged)."""
-    assert action.mask is not None
-    return BatchedAction(
-        torch.cat([torch.zeros_like(action.act[:1]), action.act], dim=0),
-        torch.cat([torch.zeros_like(action.mask[:1]), action.mask], dim=0),
-    )
+    n_axis = action.act.ndim - action.event_dim - 1
+    zero_act = torch.zeros_like(torch.narrow(action.act, n_axis, 0, 1))
+    new_act = torch.cat([zero_act, action.act], dim=n_axis)
+    new_mask = torch.cat([torch.zeros_like(action.mask[..., :1]), action.mask], dim=-1)
+    return BatchedAction(act=new_act, mask=new_mask, event_dim=action.event_dim)
 
 
 def batch_scenarios(*dicts: Mapping[Hashable, torch.Tensor]) -> dict[Hashable, BatchedAction]:
-    """Convert per-scenario ``{site: tensor}`` dicts to a ``{site: BatchedAction}`` mapping.
+    """Convert per-scenario ``{site: tensor}`` dicts into a ``{site: BatchedAction}`` mapping.
 
-    Masks are inferred from key presence. Action tensors of different shapes are broadcast
-    before stacking, so a scalar intervention broadcasts to match a vector one.
+    Infers masks from key presence. Broadcasts and stacks action tensors of differing shapes.
 
-    :param dicts: One dict per scenario mapping site names to intervention tensors.
-    :returns: ``{site: BatchedAction}`` suitable for passing to
-        :func:`~chirho.interventional.handlers.do`.
+    :param dicts: One dict per scenario, mapping site names to intervention tensors.
+    :returns: ``{site: BatchedAction}`` for use with :func:`~chirho.interventional.handlers.do`.
 
     Example::
 
@@ -299,20 +295,20 @@ def batch_scenarios(*dicts: Mapping[Hashable, torch.Tensor]) -> dict[Hashable, B
         masks = torch.tensor([v is not None for v in raw])
         real = next(v for v in raw if v is not None)
         filled = [torch.zeros((), dtype=real.dtype) if v is None else v for v in raw]  # type: ignore[union-attr]
-        stacked = torch.stack(list(torch.broadcast_tensors(*filled)))
-        result[site] = BatchedAction(act=stacked, mask=masks)
+        broadcasted = list(torch.broadcast_tensors(*filled))
+        stacked = torch.stack(broadcasted)
+        result[site] = BatchedAction(act=stacked, mask=masks, event_dim=broadcasted[0].ndim)
     return result
 
 
 class BatchedWorldCounterfactual(IndexPlatesMessenger, BaseCounterfactualMessenger):
-    """Evaluate N heterogeneous intervention scenarios on a single shared index-plate axis.
+    """Run N intervention scenarios in one vectorized pass on a single shared index-plate axis.
 
-    Memory is linear in N (vs :class:`MultiWorldCounterfactual`'s exponential in sites).
-    Index 0 is the factual world; indices ``1..N`` are the scenarios.  Results are read with
+    Index 0 is the factual world; indices ``1..N`` are the scenarios. Read results with
     ``gather(value, IndexSet(batched_interventions={k}), event_dim=...)``.
 
-    Interventions are passed via :func:`~chirho.interventional.handlers.do` using
-    :class:`BatchedAction` values.  The five main usage patterns:
+    Pass interventions via :func:`~chirho.interventional.handlers.do` using
+    :class:`BatchedAction` values. Five usage patterns:
 
     **1. Sweep one site over N values** (no mask needed)::
 
@@ -331,7 +327,7 @@ class BatchedWorldCounterfactual(IndexPlatesMessenger, BaseCounterfactualMesseng
         with BatchedWorldCounterfactual():
             with do(actions=actions):
                 z, x, y = model()
-        # 3 scenarios share one axis instead of MWC's 2x2 cross-product
+        # 3 scenarios on one axis
 
     **3. Scenario dicts via** :func:`batch_scenarios` (masks inferred from key presence)::
 
@@ -358,10 +354,10 @@ class BatchedWorldCounterfactual(IndexPlatesMessenger, BaseCounterfactualMesseng
                 z, x, y = model()
         # world 0: factual; worlds 1..N: sufficiency; worlds N+1..2N: necessity
 
-    **5. Learned selection** (float mask, differentiable in both ``act`` and ``mask``)::
+    **5. Learned selection** (differentiable float mask via straight-through estimator)::
 
-        w = torch.sigmoid(logits)             # requires_grad, shape (N,)
-        w = (w > 0.5).to(w) - w.detach() + w  # straight-through: k-hot forward, soft gradient
+        w = torch.sigmoid(logits)              # shape (N,), requires_grad
+        w = (w > 0.5).to(w) - w.detach() + w  # 0/1 forward, soft gradient
         with BatchedWorldCounterfactual():
             with do(actions={"z": BatchedAction(act=z_vals, mask=w)}):
                 z, x, y = model()
@@ -369,20 +365,14 @@ class BatchedWorldCounterfactual(IndexPlatesMessenger, BaseCounterfactualMesseng
 
     .. note::
         Nesting inside another :class:`~chirho.indexed.handlers.IndexPlatesMessenger`
-        subclass (e.g. :class:`MultiWorldCounterfactual`) is not currently supported
-        and raises ``ValueError`` — the same pre-existing limitation as nesting MWC
-        inside :class:`TwinWorldCounterfactual`.
+        subclass raises ``ValueError``.
 
     :param first_available_dim: Leftmost dimension available for index plates.
     """
 
     @staticmethod
     def _pyro_intervene(msg: dict[str, Any]) -> None:
-        # Only convert BatchedAction interventions to split.  Plain tensors and
-        # tuples are returned as-is (the default _intervene_atom body runs) so
-        # that a vanilla do() inside BatchedWorldCounterfactual broadcasts its
-        # value across the existing batched_interventions axis rather than
-        # creating a new per-site plate.
+        # Plain tensors/tuples fall through to the default handler and broadcast uniformly.
         if isinstance(msg["args"][1], BatchedAction):
             BaseCounterfactualMessenger._pyro_intervene(msg)
 
@@ -392,14 +382,16 @@ class BatchedWorldCounterfactual(IndexPlatesMessenger, BaseCounterfactualMesseng
             return
 
         action = acts[0]
-        event_dim = msg["kwargs"].get("event_dim", 0)
+        event_dim = action.event_dim
 
         full_action = _prepend_factual_world(action)
         batch_size = full_action.batch_size
 
-        act_value = unbind_leftmost_dim(full_action.act, _DEFAULT_BATCH_NAME, size=batch_size, event_dim=event_dim)
+        act_t = full_action.act.movedim(full_action.act.ndim - event_dim - 1, 0)  # (N+1, *batch, *event_shape)
+        act_value = unbind_leftmost_dim(act_t, _DEFAULT_BATCH_NAME, size=batch_size, event_dim=event_dim)
+        mask_t = full_action.mask.movedim(-1, 0)  # (*batch, N+1) -> (N+1, *batch)
         mask = unbind_leftmost_dim(
-            full_action.mask.reshape(full_action.mask.shape + (1,) * event_dim),
+            mask_t.reshape(mask_t.shape + (1,) * event_dim),
             _DEFAULT_BATCH_NAME,
             size=batch_size,
             event_dim=event_dim,

--- a/chirho/counterfactual/handlers/counterfactual.py
+++ b/chirho/counterfactual/handlers/counterfactual.py
@@ -209,28 +209,51 @@ class BatchedAction:
     """Per-site batched intervention for use with :class:`BatchedWorldCounterfactual`.
 
     :param act: Shape ``(N, *event_shape)``. Intervention value for each scenario.
-    :param mask: Shape ``(N,)`` bool. Which scenarios intervene on this site.
-        Defaults to all-True.
+    :param mask: Shape ``(N,)``, bool or floating point. Which scenarios intervene on
+        this site. Defaults to all-True.
+    :param validate_args: If True, check that a floating point ``mask`` lies in ``[0, 1]``.
 
-    Slots where ``mask`` is ``False`` are never read by ``torch.where``; their
-    values are irrelevant placeholders. All ``BatchedAction`` objects in a single
-    run must share the same leading size N.
+    A bool ``mask`` gates. ``torch.where`` never reads slots where it is ``False``,
+    so their ``act`` values are irrelevant placeholders.
+
+    A floating point ``mask`` ``w`` blends, ``w * act + (1 - w) * obs``, and passes
+    gradient to both ``act`` and ``w``. Autograd rejects ``requires_grad`` on bool, so
+    a floating point dtype is the only way to learn a mask. Values of exactly 0 or 1
+    match the bool path bit for bit; that is the intended use, typically via a
+    straight-through estimator. Intermediate values give a soft intervention, and
+    identification results that assume atomic interventions no longer hold. Values
+    outside ``[0, 1]`` extrapolate. The blend multiplies both branches instead of
+    picking one, so it requires a floating point site and finite ``act`` and ``obs``.
+    Integer masks raise.
+
+    All ``BatchedAction`` objects in a single run must share the same leading size N.
     """
 
     act: torch.Tensor
     mask: torch.Tensor
 
-    def __init__(self, act: torch.Tensor, mask: torch.Tensor | None = None):
+    def __init__(
+        self,
+        act: torch.Tensor,
+        mask: torch.Tensor | None = None,
+        *,
+        validate_args: bool = False,
+    ):
         self.act = act
         if mask is None:
             self.mask = torch.ones(self.act.shape[0], dtype=torch.bool)
-        else:
-            if self.act.shape[0] != mask.shape[0]:
-                raise ValueError(
-                    f"act and mask must have the same leading dimension, "
-                    f"got act.shape[0]={self.act.shape[0]} and mask.shape[0]={mask.shape[0]}."
-                )
-            self.mask = mask
+            return
+
+        if self.act.shape[0] != mask.shape[0]:
+            raise ValueError(
+                f"act and mask must have the same leading dimension, "
+                f"got act.shape[0]={self.act.shape[0]} and mask.shape[0]={mask.shape[0]}."
+            )
+        if mask.dtype is not torch.bool and not mask.is_floating_point():
+            raise ValueError(f"mask must be bool or floating point, got dtype {mask.dtype}.")
+        if validate_args and mask.is_floating_point() and not ((mask >= 0.0) & (mask <= 1.0)).all():
+            raise ValueError("floating point mask must lie in [0, 1].")
+        self.mask = mask
 
     @property
     def batch_size(self) -> int:
@@ -289,7 +312,7 @@ class BatchedWorldCounterfactual(IndexPlatesMessenger, BaseCounterfactualMesseng
     ``gather(value, IndexSet(batched_interventions={k}), event_dim=...)``.
 
     Interventions are passed via :func:`~chirho.interventional.handlers.do` using
-    :class:`BatchedAction` values.  The four main usage patterns:
+    :class:`BatchedAction` values.  The five main usage patterns:
 
     **1. Sweep one site over N values** (no mask needed)::
 
@@ -335,6 +358,15 @@ class BatchedWorldCounterfactual(IndexPlatesMessenger, BaseCounterfactualMesseng
                 z, x, y = model()
         # world 0: factual; worlds 1..N: sufficiency; worlds N+1..2N: necessity
 
+    **5. Learned selection** (float mask, differentiable in both ``act`` and ``mask``)::
+
+        w = torch.sigmoid(logits)             # requires_grad, shape (N,)
+        w = (w > 0.5).to(w) - w.detach() + w  # straight-through: k-hot forward, soft gradient
+        with BatchedWorldCounterfactual():
+            with do(actions={"z": BatchedAction(act=z_vals, mask=w)}):
+                z, x, y = model()
+        loss(y).backward()                    # logits.grad is populated
+
     .. note::
         Nesting inside another :class:`~chirho.indexed.handlers.IndexPlatesMessenger`
         subclass (e.g. :class:`MultiWorldCounterfactual`) is not currently supported
@@ -372,6 +404,16 @@ class BatchedWorldCounterfactual(IndexPlatesMessenger, BaseCounterfactualMesseng
             size=batch_size,
             event_dim=event_dim,
         )
-        msg["value"] = torch.where(mask, act_value, obs)
+        if mask.dtype is torch.bool:
+            msg["value"] = torch.where(mask, act_value, obs)
+        else:
+            if not obs.is_floating_point():
+                raise ValueError(
+                    f"a floating point BatchedAction.mask blends against the site value, which "
+                    f"requires a floating point site, but {msg['kwargs'].get('name')!r} has dtype "
+                    f"{obs.dtype}. Use a bool mask for discrete sites."
+                )
+            w = mask.to(obs.dtype)
+            msg["value"] = w * act_value + (1 - w) * obs
         msg["done"] = True
         msg["stop"] = True

--- a/tests/interventional/test_batched_interventions.py
+++ b/tests/interventional/test_batched_interventions.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import math
 import time
@@ -22,6 +23,35 @@ logger = logging.getLogger(__name__)
 
 EVENT_SHAPES = [(), (4,), (4, 3)]
 FIRST_AVAILABLE_DIMS = [-1, -2, None]
+MASK_DTYPES = [torch.bool, torch.float32]
+
+
+@pytest.fixture(params=MASK_DTYPES, ids=str)
+def mask_dtype(request):
+    """Run a test under both mask representations.
+
+    At w in {0, 1} the float blend is meant to be a drop-in for the bool gate,
+    so rather than duplicating assertions this recasts every ``BatchedAction``
+    mask the test builds -- including the ones :func:`batch_scenarios` and the
+    ``mask=None`` default construct, which the test never sees.
+    """
+    dtype = request.param
+    if dtype is torch.bool:
+        yield dtype
+        return
+
+    original = BatchedAction.__init__
+
+    def cast_mask(self, act, mask=None, **kwargs):
+        original(self, act, mask, **kwargs)
+        if self.mask.dtype is torch.bool:
+            self.mask = self.mask.to(dtype)
+
+    BatchedAction.__init__ = cast_mask
+    try:
+        yield dtype
+    finally:
+        BatchedAction.__init__ = original
 
 
 def scm(event_shape=()):
@@ -43,7 +73,7 @@ def scm(event_shape=()):
 
 
 @pytest.mark.parametrize("first_available_dim", FIRST_AVAILABLE_DIMS)
-def test_smoke(first_available_dim):
+def test_smoke(first_available_dim, mask_dtype):
     # Analogous to test_counterfactual_handler_smoke: factual world plus the
     # requested intervention scenarios, addressable by index.
     with BatchedWorldCounterfactual(first_available_dim=first_available_dim):
@@ -58,7 +88,7 @@ def test_smoke(first_available_dim):
 
 @pytest.mark.parametrize("first_available_dim", FIRST_AVAILABLE_DIMS)
 @pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
-def test_matches_mwc_single_site(event_shape, first_available_dim):
+def test_matches_mwc_single_site(event_shape, first_available_dim, mask_dtype):
     # With shared noise each batched world is exactly the corresponding gathered
     # slice of MultiWorldCounterfactual, including with non-trivial event dims.
     event_dim = len(event_shape)
@@ -83,7 +113,7 @@ def test_matches_mwc_single_site(event_shape, first_available_dim):
 
 
 @pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
-def test_multiple_interventions_stay_on_single_axis(event_shape):
+def test_multiple_interventions_stay_on_single_axis(event_shape, mask_dtype):
     # The defining property: interventions on *different* sites share one axis.
     event_dim = len(event_shape)
     za = torch.full(event_shape, 3.0)
@@ -101,7 +131,7 @@ def test_multiple_interventions_stay_on_single_axis(event_shape):
 
 
 @pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
-def test_conditioning_applies_to_factual_world(event_shape):
+def test_conditioning_applies_to_factual_world(event_shape, mask_dtype):
     # Observed data is applied only to the factual world (index 0); intervened
     # scenarios keep their counterfactual values.
     event_dim = len(event_shape)
@@ -125,7 +155,7 @@ def test_conditioning_applies_to_factual_world(event_shape):
             assert (s1 < 5.0).all()  # y ~ Normal(0.8 * -10 + ..., 1)
 
 
-def test_dim_allocation_failure():
+def test_dim_allocation_failure(mask_dtype):
     # An index plate that collides with a model plate raises an informative error;
     # a different first_available_dim resolves it.
     def model():
@@ -149,7 +179,7 @@ def test_dim_allocation_failure():
 # ---------------------------------------------------------------------------
 
 
-def test_dense_sweep_no_mask():
+def test_dense_sweep_no_mask(mask_dtype):
     # BatchedAction without a mask: every scenario intervenes on the site.
     z_vals = torch.linspace(-3.0, 3.0, 5)  # shape (5,)
 
@@ -163,9 +193,10 @@ def test_dense_sweep_no_mask():
                 assert zi == val
 
 
-def test_explicit_mask():
-    # BatchedAction with explicit mask: only scenarios where mask=True intervene;
-    # others pass through the factual (propagated) value.
+def test_explicit_mask(mask_dtype):
+    # BatchedAction with explicit mask: only scenarios where the mask selects
+    # intervene; others pass through the factual (propagated) value.  A float
+    # mask holding exactly 0.0/1.0 must reproduce the bool gate exactly.
     actions = {
         "z": BatchedAction(
             act=torch.tensor([1.0, 2.0, 0.0]),
@@ -194,7 +225,7 @@ def test_explicit_mask():
             assert gather(x, IndexSet(batched_interventions={3})).reshape(()) == 3.0
 
 
-def test_batch_scenarios_convenience():
+def test_batch_scenarios_convenience(mask_dtype):
     # batch_scenarios infers masks from key presence; same result as building
     # BatchedAction manually.
     manual = {
@@ -219,7 +250,7 @@ def test_batch_scenarios_convenience():
         assert torch.equal(auto[site].mask, manual[site].mask)
 
 
-def test_gather_isolates_scenarios_and_propagates():
+def test_gather_isolates_scenarios_and_propagates(mask_dtype):
     # Scenario i lives at index i+1; non-intervened sites propagate upstream
     # interventions rather than reverting to the global factual.
     with BatchedWorldCounterfactual():
@@ -243,7 +274,7 @@ def test_gather_isolates_scenarios_and_propagates():
             assert world(y, 1) > 10.0
 
 
-def test_factual_world_present():
+def test_factual_world_present(mask_dtype):
     with BatchedWorldCounterfactual():
         with do(actions=batch_scenarios({"z": torch.tensor(100.0)}, {"z": torch.tensor(200.0)})):
             z, _, _ = scm()()
@@ -253,7 +284,7 @@ def test_factual_world_present():
 
 
 @pytest.mark.parametrize("event_shape", [(4,), (4, 3)], ids=str)
-def test_event_dim(event_shape):
+def test_event_dim(event_shape, mask_dtype):
     # Non-trivial event dimensions with batch_scenarios.
     event_dim = len(event_shape)
     batch_size = 3
@@ -271,7 +302,7 @@ def test_event_dim(event_shape):
 
 
 @pytest.mark.parametrize("event_shape", [(4,), (4, 3)], ids=str)
-def test_event_dim_explicit_mask(event_shape):
+def test_event_dim_explicit_mask(event_shape, mask_dtype):
     # BatchedAction with explicit mask and non-trivial event dims.
     event_dim = len(event_shape)
     act = torch.stack([torch.full(event_shape, 10.0), torch.full(event_shape, 20.0)])
@@ -288,7 +319,7 @@ def test_event_dim_explicit_mask(event_shape):
             assert not torch.allclose(s2.reshape(-1), torch.full(event_shape, 20.0).reshape(-1))
 
 
-def test_broadcasts_mixed_shapes():
+def test_broadcasts_mixed_shapes(mask_dtype):
     # batch_scenarios broadcasts action tensors of different shapes together.
     event_shape = (4,)
     with BatchedWorldCounterfactual():
@@ -305,7 +336,7 @@ def test_broadcasts_mixed_shapes():
             assert torch.allclose(s2.reshape(-1), torch.full(event_shape, 9.0))
 
 
-def test_aligned_multisite_interventions():
+def test_aligned_multisite_interventions(mask_dtype):
     # Two sites with aligned values yield N zipped worlds (not a cross product).
     xs = [torch.tensor(v) for v in (10.0, 20.0, 30.0)]
     ys = [torch.tensor(v) for v in (-1.0, -2.0, -3.0)]
@@ -319,7 +350,7 @@ def test_aligned_multisite_interventions():
                 assert gather(y, IndexSet(batched_interventions={i + 1})).reshape(()) == ys[i]
 
 
-def test_matches_mwc_multisite_leaf():
+def test_matches_mwc_multisite_leaf(mask_dtype):
     # Multi-site equivalence to MWC: leaf-site interventions match MWC cells exactly.
     def model():
         z = pyro.sample("z", dist.Normal(0.0, 1.0))
@@ -358,7 +389,7 @@ def test_matches_mwc_multisite_leaf():
         assert torch.allclose(batched[i], mwc[i])
 
 
-def test_handler_usable_as_decorator():
+def test_handler_usable_as_decorator(mask_dtype):
     # BWC is usable as a decorator — do() wraps the model inside BWC's scope.
     n = 3
     acts = torch.tensor([float(i) for i in range(n)])
@@ -368,7 +399,7 @@ def test_handler_usable_as_decorator():
 
 
 @pytest.mark.parametrize("num_sites", [2, 4, 6])
-def test_linear_memory_vs_mwc_cross_product(num_sites):
+def test_linear_memory_vs_mwc_cross_product(num_sites, mask_dtype):
     # MWC represents the cross product (2**num_sites worlds); BWC keeps one axis.
     def chain_model():
         prev = pyro.sample("s0", dist.Normal(0.0, 1.0))
@@ -391,7 +422,7 @@ def test_linear_memory_vs_mwc_cross_product(num_sites):
     assert last_batched.numel() == num_sites + 1  # factual + scenarios
 
 
-def test_pci_like_pattern():
+def test_pci_like_pattern(mask_dtype):
     # PCI evaluates N (sufficiency, necessity) pairs in one pass. Masks and values
     # are pre-sampled tensors; the 2N scenarios are assembled with torch.cat.
     N = 4
@@ -427,17 +458,254 @@ def test_pci_like_pattern():
                 assert suff_y[i] != nec_y[i] or (not masks["z"][i] and not masks["x"][i])
 
 
-def test_errors():
-    # BatchedAction validates act/mask shape consistency.
+def test_rejects_mismatched_act_and_mask_shapes():
     with pytest.raises(ValueError, match="same leading dimension"):
         BatchedAction(act=torch.tensor([1.0, 2.0]), mask=torch.tensor([True]))
 
-    # batch_scenarios requires at least one dict.
+
+def test_rejects_empty_batch_scenarios():
     with pytest.raises(ValueError, match="at least one"):
         batch_scenarios()
 
 
-def test_batched_evaluates_model_once():
+# ---------------------------------------------------------------------------
+# Floating point masks: blend against the realized value instead of gating.
+# ---------------------------------------------------------------------------
+
+
+def chain():
+    """A noiseless chain z -> x -> y, so propagation is exactly checkable."""
+    z = pyro.sample("z", dist.Normal(0.0, 1.0))
+    x = pyro.sample("x", dist.Delta(z + 1.0))
+    y = pyro.sample("y", dist.Delta(2.0 * x))
+    return z, x, y
+
+
+@contextlib.contextmanager
+def _run(actions, model=None, seed=0):
+    """Run a model under BWC and yield its return value, staying inside the
+    index plates so that ``gather`` remains valid in the test body."""
+    pyro.set_rng_seed(seed)
+    with BatchedWorldCounterfactual():
+        with do(actions=actions):
+            yield (model or scm())()
+
+
+def _world(v, i, **kwargs):
+    return gather(v, IndexSet(batched_interventions={i}), **kwargs).reshape(())
+
+
+def test_rejects_integer_mask_dtype():
+    # An integer mask is almost certainly a caller who meant bool, and would
+    # otherwise take the blend path and promote the site's dtype.
+    with pytest.raises(ValueError, match="bool or floating point"):
+        BatchedAction(act=torch.tensor([1.0, 2.0]), mask=torch.tensor([1, 0]))
+
+
+def test_float_mask_range_check_is_opt_in():
+    out_of_range = torch.tensor([1.7, 0.0])
+    BatchedAction(act=torch.tensor([1.0, 2.0]), mask=out_of_range)  # extrapolation is legal
+    BatchedAction(act=torch.tensor([1.0, 2.0]), mask=torch.tensor([1.0, 0.0]), validate_args=True)
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        BatchedAction(act=torch.tensor([1.0, 2.0]), mask=out_of_range, validate_args=True)
+
+
+def test_float_mask_requires_floating_point_site():
+    # torch.where handles a discrete site; the blend would silently promote it.
+    def model():
+        return pyro.sample("c", dist.Categorical(torch.ones(3)))
+
+    act = torch.tensor([1, 2])
+    with _run({"c": BatchedAction(act=act, mask=torch.tensor([True, False]))}, model=model) as c:
+        assert not c.is_floating_point()
+
+    with pytest.raises(ValueError, match="floating point site"):
+        with _run({"c": BatchedAction(act=act, mask=torch.tensor([1.0, 0.0]))}, model=model):
+            pass
+
+
+def _multisite_case():
+    acts = {"z": torch.tensor([1.0, 2.0, 0.0]), "x": torch.tensor([0.0, 3.0, 3.0])}
+    bools = {"z": [True, True, False], "x": [False, True, True]}
+    return scm(), {s: (acts[s], torch.tensor(bools[s])) for s in acts}
+
+
+def _event_dim_case(event_shape):
+    act = torch.stack([torch.full(event_shape, 10.0), torch.full(event_shape, 20.0)])
+    return scm(event_shape), {"z": (act, torch.tensor([True, False]))}
+
+
+def _broadcast_case():
+    act = torch.stack(torch.broadcast_tensors(torch.tensor(1.0), torch.full((4,), 2.0)))
+    return scm((4,)), {"z": (act, torch.tensor([True, False]))}
+
+
+EQUIVALENCE_CASES = {
+    "multisite": _multisite_case,
+    "event_dim_1": lambda: _event_dim_case((4,)),
+    "event_dim_2": lambda: _event_dim_case((4, 3)),
+    "broadcast": _broadcast_case,
+    "all_selected": lambda: (scm(), {"z": (torch.tensor([1.0, 2.0]), torch.tensor([True, True]))}),
+    "none_selected": lambda: (scm(), {"z": (torch.tensor([1.0, 2.0]), torch.tensor([False, False]))}),
+}
+
+
+@pytest.mark.parametrize("float_dtype", [torch.float32, torch.float64], ids=str)
+@pytest.mark.parametrize("case", list(EQUIVALENCE_CASES), ids=str)
+def test_float_mask_bit_identical_to_bool_mask(case, float_dtype):
+    # A float mask of exact 0.0/1.0 is bit-identical to the corresponding bool
+    # mask, not merely close.  torch.equal also pins the two-term blend form:
+    # obs + w * (act - obs) is algebraically equal but rounds at the endpoints.
+    model, spec = EQUIVALENCE_CASES[case]()
+
+    def run(dtype):
+        actions = {s: BatchedAction(act=a, mask=m.to(dtype)) for s, (a, m) in spec.items()}
+        with _run(actions, model=model) as values:
+            return [v.clone() for v in values]
+
+    for hard, soft in zip(run(torch.bool), run(float_dtype)):
+        assert hard.dtype is soft.dtype
+        assert torch.equal(hard, soft)
+
+
+def test_bool_mask_blocks_gradient():
+    # The behaviour this change works around, stated as a test so the contrast
+    # with the float path is explicit rather than folklore.
+    logits = torch.tensor([2.0, -2.0], requires_grad=True)
+    act = torch.tensor([10.0, 20.0], requires_grad=True)
+    mask = (torch.sigmoid(logits) > 0.5).bool()
+    assert not mask.requires_grad
+
+    with _run({"z": BatchedAction(act=act, mask=mask)}) as (z, _, _):
+        gather(z, IndexSet(batched_interventions={1, 2})).sum().backward()
+
+    assert act.grad is not None  # the graph exists...
+    assert logits.grad is None  # ...but torch.where's condition is a dead end
+
+
+def test_float_mask_backpropagates_to_mask():
+    # The regression test for this change.
+    logits = torch.tensor([2.0, -2.0, 0.5], requires_grad=True)
+    act = torch.tensor([10.0, 20.0, 30.0])
+
+    with _run({"z": BatchedAction(act=act, mask=torch.sigmoid(logits))}) as (z, _, _):
+        gather(z, IndexSet(batched_interventions={1, 2, 3})).sum().backward()
+
+    assert logits.grad is not None
+    assert (logits.grad != 0).all()
+
+
+def test_float_mask_backpropagates_through_downstream_sites():
+    # Gradient must survive propagation: the loss is on y, two sites downstream
+    # of the intervened z, with no direct path back to the mask.
+    logits = torch.tensor([1.0, -1.0], requires_grad=True)
+    act = torch.tensor([5.0, 7.0])
+
+    with _run({"z": BatchedAction(act=act, mask=torch.sigmoid(logits))}, model=chain) as (_, _, y):
+        gather(y, IndexSet(batched_interventions={1, 2})).sum().backward()
+
+    assert logits.grad is not None
+    assert (logits.grad != 0).all()
+
+
+def test_float_mask_gradient_matches_analytic_contrast():
+    # d value / d w is act - obs, the causal contrast at the model's realized
+    # value rather than against a stale reference.
+    w = torch.tensor([1.0, 0.0], requires_grad=True)
+    act = torch.tensor([10.0, 20.0])
+
+    with _run({"z": BatchedAction(act=act, mask=w)}) as (z, _, _):
+        obs = _world(z, 0)
+        gather(z, IndexSet(batched_interventions={1, 2})).sum().backward()
+
+    assert torch.allclose(w.grad, act - obs)
+
+
+def test_float_mask_backpropagates_to_act_and_mask_together():
+    logits = torch.tensor([2.0, -2.0], requires_grad=True)
+    act = torch.tensor([10.0, 20.0], requires_grad=True)
+
+    with _run({"z": BatchedAction(act=act, mask=torch.sigmoid(logits))}) as (z, _, _):
+        gather(z, IndexSet(batched_interventions={1, 2})).sum().backward()
+
+    assert (logits.grad != 0).all()
+    assert (act.grad != 0).all()
+
+
+def test_float_mask_straight_through():
+    # The recommended pattern: exactly k-hot on the forward pass, relaxed only
+    # in the gradient, so the soft regime never materializes.
+    logits = torch.tensor([3.0, -3.0], requires_grad=True)
+    soft = torch.sigmoid(logits)
+    w = (soft > 0.5).to(soft) - soft.detach() + soft
+
+    with _run({"z": BatchedAction(act=torch.tensor([10.0, 20.0]), mask=w)}) as (z, _, _):
+        assert _world(z, 1) == 10.0
+        assert _world(z, 2) != 20.0  # w=0, free-running rather than intervened
+        gather(z, IndexSet(batched_interventions={1, 2})).sum().backward()
+
+    assert logits.grad is not None
+    assert (logits.grad != 0).all()
+
+
+def test_float_mask_factual_world_inert():
+    # _prepend_factual_world uses zeros_like, which for a float mask is a
+    # detached 0.0: world 0 is the un-intervened value and leaks no gradient.
+    logits = torch.zeros(2, requires_grad=True)
+    act = torch.tensor([10.0, 20.0])
+
+    with _run({"z": BatchedAction(act=act, mask=torch.sigmoid(logits))}) as (z_soft, _, _):
+        soft_factual = _world(z_soft, 0)
+        soft_factual.backward()
+    with _run({"z": BatchedAction(act=act, mask=torch.tensor([True, True]))}) as (z_bool, _, _):
+        bool_factual = _world(z_bool, 0)
+
+    assert torch.equal(soft_factual.detach(), bool_factual)
+    assert logits.grad is None or (logits.grad == 0).all()
+
+
+def test_float_mask_zero_is_free_running_not_pinned():
+    # The property the external-blend workaround cannot reach.  z is upstream of
+    # x; intervening on z with w=1 and on x with w=0 must leave x propagating
+    # from the intervened z (6.0), not pinned to its clean value.
+    actions = {
+        "z": BatchedAction(act=torch.tensor([5.0]), mask=torch.tensor([1.0])),
+        "x": BatchedAction(act=torch.tensor([100.0]), mask=torch.tensor([0.0])),
+    }
+    with _run(actions, model=chain) as (z, x, y):
+        assert _world(z, 1) == 5.0
+        assert _world(x, 1) == 6.0
+        assert _world(y, 1) == 12.0
+
+
+def test_float_mask_soft_interpolation():
+    # w in (0, 1) is a convex interpolation, not an atomic intervention.
+    action = {"z": BatchedAction(act=torch.tensor([10.0, 10.0]), mask=torch.tensor([0.0, 0.5]))}
+    with _run(action) as (z, _, _):
+        obs = _world(z, 1)
+        assert torch.allclose(_world(z, 2), 0.5 * obs + 0.5 * torch.tensor(10.0))
+
+
+def test_float_mask_casts_to_site_dtype():
+    # A float64 mask must not promote a float32 site.
+    mask = torch.tensor([0.5], dtype=torch.float64)
+    with _run({"z": BatchedAction(act=torch.tensor([10.0]), mask=mask)}) as (z, _, _):
+        assert z.dtype is torch.float32
+
+
+def test_float_mask_composition_with_plain_do():
+    # A plain do() nested inside still broadcasts uniformly over the float path.
+    action = {"z": BatchedAction(act=torch.tensor([100.0, 200.0]), mask=torch.tensor([1.0, 1.0]))}
+    with _run(action) as _:
+        with do(actions={"x": torch.tensor(0.0)}):
+            z, x, _ = scm()()
+
+            assert _world(z, 1) == 100.0 and _world(z, 2) == 200.0
+            assert _world(z, 0) != 100.0 and _world(z, 0) != 200.0
+            assert all(_world(x, i) == 0.0 for i in range(3))
+
+
+def test_batched_evaluates_model_once(mask_dtype):
     # One vectorized forward pass regardless of batch size.
     n = 5
     acts = torch.tensor([float(i) for i in range(n)])
@@ -463,7 +731,7 @@ def test_batched_evaluates_model_once():
     assert calls == 1  # batched: single vectorized call
 
 
-def test_composition_with_plain_do():
+def test_composition_with_plain_do(mask_dtype):
     # A plain do() inside BWC applies its action uniformly to all worlds.
     # The plain do falls through BWC's _pyro_split (wrong type) to the standard
     # Interventions handler, which broadcasts across the existing batch axis.
@@ -488,7 +756,7 @@ def test_composition_with_plain_do():
                 assert world(y, 2) > world(y, 1)  # z=200 vs z=100, gap >> 1-sigma noise
 
 
-def test_composition_bwc_mwc_raises():
+def test_composition_bwc_mwc_raises(mask_dtype):
     # Nesting BWC inside another IndexPlatesMessenger subclass (MWC) is a known
     # limitation: both try to enter a Pyro plate with the same name.
     # This is the same pre-existing issue as nesting MWC + TwinWorldCounterfactual.

--- a/tests/interventional/test_batched_interventions.py
+++ b/tests/interventional/test_batched_interventions.py
@@ -309,7 +309,7 @@ def test_event_dim_explicit_mask(event_shape, mask_dtype):
     mask = torch.tensor([True, False])
 
     with BatchedWorldCounterfactual():
-        with do(actions={"z": BatchedAction(act=act, mask=mask)}):
+        with do(actions={"z": BatchedAction(act=act, mask=mask, event_dim=event_dim)}):
             z, _, _ = scm(event_shape)()
             assert indices_of(z, event_dim=event_dim)["batched_interventions"] == {0, 1, 2}
             s1 = gather(z, IndexSet(batched_interventions={1}), event_dim=event_dim)
@@ -459,8 +459,112 @@ def test_pci_like_pattern(mask_dtype):
 
 
 def test_rejects_mismatched_act_and_mask_shapes():
-    with pytest.raises(ValueError, match="same leading dimension"):
+    with pytest.raises(ValueError, match="last dimension"):
         BatchedAction(act=torch.tensor([1.0, 2.0]), mask=torch.tensor([True]))
+
+
+@pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
+def test_default_mask_inherits_device(event_shape):
+    act = torch.ones(3, *event_shape, device="meta")
+    ba = BatchedAction(act=act)
+    assert ba.mask.device.type == "meta"
+
+
+MASK_BATCH_SHAPES = [(), (3,), (3, 2)]
+
+
+@pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
+@pytest.mark.parametrize("mask_batch_shape", MASK_BATCH_SHAPES, ids=str)
+def test_mask_batch_shapes_accepted(mask_batch_shape, event_shape):
+    # mask is (*batch, N); act is (*batch, N, *event_shape); N is always at -(event_dim+1).
+    N = 3
+    event_dim = len(event_shape)
+    act = torch.ones(N, *event_shape)
+    mask = torch.ones(*mask_batch_shape, N, dtype=torch.bool)
+    ba = BatchedAction(act=act, mask=mask, event_dim=event_dim)
+    assert ba.mask.shape == torch.Size([*mask_batch_shape, N])
+    assert ba.batch_size == N
+
+
+@pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
+@pytest.mark.parametrize("mask_batch_shape", MASK_BATCH_SHAPES, ids=str)
+def test_mask_batch_shapes_forward(mask_batch_shape, event_shape):
+    # Masks with upstream batch dims run without error and produce the expected worlds.
+    N = 2
+    event_dim = len(event_shape)
+    act = torch.stack([torch.full(event_shape, 10.0), torch.full(event_shape, -10.0)])
+    mask = torch.ones(*mask_batch_shape, N, dtype=torch.bool)
+
+    with BatchedWorldCounterfactual():
+        with do(actions={"z": BatchedAction(act=act, mask=mask, event_dim=event_dim)}):
+            z, x, y = scm(event_shape)()
+            assert indices_of(z, event_dim=event_dim) == IndexSet(batched_interventions={0, 1, 2})
+
+
+@pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
+@pytest.mark.parametrize("mask_batch_shape", MASK_BATCH_SHAPES, ids=str)
+def test_float_mask_batch_shape_differentiable(mask_batch_shape, event_shape):
+    # Gradients flow through float masks with upstream batch dims and non-trivial event shapes.
+    N = 2
+    event_dim = len(event_shape)
+    act = torch.stack([torch.full(event_shape, 5.0), torch.full(event_shape, 10.0)]).requires_grad_(True)
+    logits = torch.zeros(*mask_batch_shape, N, requires_grad=True)
+
+    with _run({"z": BatchedAction(act=act, mask=torch.sigmoid(logits), event_dim=event_dim)}) as (z, _, _):
+        gather(z, IndexSet(batched_interventions={1, 2}), event_dim=event_dim).sum().backward()
+
+    assert logits.grad is not None and logits.grad.shape == logits.shape
+    assert act.grad is not None
+
+
+@pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
+def test_batch_mask_value_correctness(event_shape):
+    # Row 0 is active in world 1 only; row 1 is active in world 2 only.
+    B = 2
+    event_dim = len(event_shape)
+    act = torch.stack([torch.full(event_shape, 10.0), torch.full(event_shape, -10.0)])
+    mask = torch.tensor([[True, False], [False, True]])  # (B, N)
+
+    pyro.set_rng_seed(0)
+    with BatchedWorldCounterfactual():
+        with do(actions={"z": BatchedAction(act=act, mask=mask, event_dim=event_dim)}):
+            z, _, _ = scm(event_shape)()
+            obs = gather(z, IndexSet(batched_interventions={0}), event_dim=event_dim)
+            world1 = gather(z, IndexSet(batched_interventions={1}), event_dim=event_dim)
+            world2 = gather(z, IndexSet(batched_interventions={2}), event_dim=event_dim)
+
+    obs = obs.reshape(B, *event_shape)
+    world1 = world1.reshape(B, *event_shape)
+    world2 = world2.reshape(B, *event_shape)
+    assert torch.allclose(world1[0], torch.full(event_shape, 10.0))
+    assert torch.allclose(world1[1], obs[1])
+    assert torch.allclose(world2[0], obs[0])
+    assert torch.allclose(world2[1], torch.full(event_shape, -10.0))
+
+
+@pytest.mark.parametrize("event_shape", EVENT_SHAPES, ids=str)
+@pytest.mark.parametrize("mask_batch_shape", MASK_BATCH_SHAPES, ids=str)
+def test_batch_mask_gradient_correctness(mask_batch_shape, event_shape):
+    # d(value[*b,k]) / d(logit[*b,k]) = sigmoid'(0) * sum_e(act[k,e] - obs[*b,e]).
+    # At logits=0: sigmoid'(0) = 0.25.
+    N = 2
+    event_dim = len(event_shape)
+    prod_event = math.prod(event_shape) if event_shape else 1
+    act = torch.stack([torch.full(event_shape, 10.0), torch.full(event_shape, -10.0)])
+    logits = torch.zeros(*mask_batch_shape, N, requires_grad=True)
+
+    pyro.set_rng_seed(0)
+    with BatchedWorldCounterfactual():
+        with do(actions={"z": BatchedAction(act=act, mask=torch.sigmoid(logits), event_dim=event_dim)}):
+            z, _, _ = scm(event_shape)()
+            obs = gather(z, IndexSet(batched_interventions={0}), event_dim=event_dim).detach()
+            gather(z, IndexSet(batched_interventions={1, 2}), event_dim=event_dim).sum().backward()
+
+    batch_dims = len(mask_batch_shape)
+    obs_flat = obs.reshape(*mask_batch_shape, prod_event)  # (*batch, prod_event)
+    act_exp = act.reshape((1,) * batch_dims + (N, prod_event))  # (1,...,1, N, prod_event)
+    expected = 0.25 * (act_exp - obs_flat.unsqueeze(-2)).sum(-1)  # (*batch, N)
+    assert torch.allclose(logits.grad, expected, atol=1e-6)
 
 
 def test_rejects_empty_batch_scenarios():
@@ -502,14 +606,6 @@ def test_rejects_integer_mask_dtype():
         BatchedAction(act=torch.tensor([1.0, 2.0]), mask=torch.tensor([1, 0]))
 
 
-def test_float_mask_range_check_is_opt_in():
-    out_of_range = torch.tensor([1.7, 0.0])
-    BatchedAction(act=torch.tensor([1.0, 2.0]), mask=out_of_range)  # extrapolation is legal
-    BatchedAction(act=torch.tensor([1.0, 2.0]), mask=torch.tensor([1.0, 0.0]), validate_args=True)
-    with pytest.raises(ValueError, match=r"\[0, 1\]"):
-        BatchedAction(act=torch.tensor([1.0, 2.0]), mask=out_of_range, validate_args=True)
-
-
 def test_float_mask_requires_floating_point_site():
     # torch.where handles a discrete site; the blend would silently promote it.
     def model():
@@ -527,17 +623,17 @@ def test_float_mask_requires_floating_point_site():
 def _multisite_case():
     acts = {"z": torch.tensor([1.0, 2.0, 0.0]), "x": torch.tensor([0.0, 3.0, 3.0])}
     bools = {"z": [True, True, False], "x": [False, True, True]}
-    return scm(), {s: (acts[s], torch.tensor(bools[s])) for s in acts}
+    return scm(), {s: (acts[s], torch.tensor(bools[s]), 0) for s in acts}
 
 
 def _event_dim_case(event_shape):
     act = torch.stack([torch.full(event_shape, 10.0), torch.full(event_shape, 20.0)])
-    return scm(event_shape), {"z": (act, torch.tensor([True, False]))}
+    return scm(event_shape), {"z": (act, torch.tensor([True, False]), len(event_shape))}
 
 
 def _broadcast_case():
     act = torch.stack(torch.broadcast_tensors(torch.tensor(1.0), torch.full((4,), 2.0)))
-    return scm((4,)), {"z": (act, torch.tensor([True, False]))}
+    return scm((4,)), {"z": (act, torch.tensor([True, False]), 1)}
 
 
 EQUIVALENCE_CASES = {
@@ -545,8 +641,8 @@ EQUIVALENCE_CASES = {
     "event_dim_1": lambda: _event_dim_case((4,)),
     "event_dim_2": lambda: _event_dim_case((4, 3)),
     "broadcast": _broadcast_case,
-    "all_selected": lambda: (scm(), {"z": (torch.tensor([1.0, 2.0]), torch.tensor([True, True]))}),
-    "none_selected": lambda: (scm(), {"z": (torch.tensor([1.0, 2.0]), torch.tensor([False, False]))}),
+    "all_selected": lambda: (scm(), {"z": (torch.tensor([1.0, 2.0]), torch.tensor([True, True]), 0)}),
+    "none_selected": lambda: (scm(), {"z": (torch.tensor([1.0, 2.0]), torch.tensor([False, False]), 0)}),
 }
 
 
@@ -559,7 +655,7 @@ def test_float_mask_bit_identical_to_bool_mask(case, float_dtype):
     model, spec = EQUIVALENCE_CASES[case]()
 
     def run(dtype):
-        actions = {s: BatchedAction(act=a, mask=m.to(dtype)) for s, (a, m) in spec.items()}
+        actions = {s: BatchedAction(act=a, mask=m.to(dtype), event_dim=ed) for s, (a, m, ed) in spec.items()}
         with _run(actions, model=model) as values:
             return [v.clone() for v in values]
 


### PR DESCRIPTION
`BatchedAction.mask` now accepts a floating point tensor in addition to `bool`. A bool mask
gates through `torch.where` exactly as before. A float mask `w` blends against the site's
realized value:

```python
if mask.dtype is torch.bool:
    msg["value"] = torch.where(mask, act_value, obs)   # unchanged
else:
    w = mask.to(obs.dtype)
    msg["value"] = w * act_value + (1 - w) * obs
```

`torch.where` blocks learning *which* sites to intervene on by gradient descent, 
which is the one thing the batched machinery is otherwise well suited to.

Autograd rejects `requires_grad` on bool, so we use a floating point dtype.
A float mask holding exactly 0.0/1.0 is still a hard gate, 
and that is the intended use, typically via a straight-through estimator.
